### PR TITLE
fix(task-management): support git worktrees in router root detection

### DIFF
--- a/.opencode/skills/task-management/router.sh
+++ b/.opencode/skills/task-management/router.sh
@@ -72,14 +72,14 @@ find_project_root() {
     local dir
     dir="$(pwd)"
     while [ "$dir" != "/" ]; do
-        if [ -d "$dir/.git" ] || [ -f "$dir/package.json" ]; then
+        if [ -e "$dir/.git" ] || [ -f "$dir/package.json" ]; then
             echo "$dir"
             return 0
         fi
         dir="$(dirname "$dir")"
     done
     pwd
-    return 1
+    return 0
 }
 
 # Handle help


### PR DESCRIPTION
## Description
Fix task-management router project root detection for git worktrees.

I hit this while using OAC from a real git worktree. In that setup, `.git` is a file rather than a directory. The router only checked for `.git` as a directory, so project root detection failed inside the worktree. Because the script also runs with `set -e`, the fallback path could exit early, which made commands like `status` and `validate` return no output.

This change:
- treats `.git` as either a directory or a file when detecting the project root
- returns success from the fallback path so the router does not exit early under `set -e`
- restores task-management CLI behavior inside git worktrees

## Type of Change
- [x] Bug fix

## Checklist
- [x] Tests pass locally
- [ ] Documentation updated (if needed)
- [x] Follows [CONTRIBUTING.md](docs/contributing/CONTRIBUTING.md)

## Testing
Validated manually in both a normal repo checkout and a real git worktree where the issue was originally observed.

Commands tested:
- `bash .opencode/skills/task-management/router.sh status`
- `bash .opencode/skills/task-management/router.sh validate`

Before this change, the worktree case could exit with no output.
After this change, the router correctly finds `.tmp/tasks` and returns task status/validation results.