### PR TITLE
refactor: Enable built-in question tool for agents to preserve session continuity

### DIFF
--- a/.opencode/agent/core/openagent.md
+++ b/.opencode/agent/core/openagent.md
@@ -4,6 +4,7 @@ description: "Universal agent for answering queries, executing tasks, and coordi
 mode: primary
 temperature: 0.2
 permission:
+  question: "allow"
   bash:
     "*": "ask"
     "rm -rf *": "ask"

--- a/.opencode/agent/core/opencoder.md
+++ b/.opencode/agent/core/opencoder.md
@@ -4,6 +4,7 @@ description: "Orchestration agent for complex coding, architecture, and multi-fi
 mode: primary
 temperature: 0.1
 permission:
+  question: "allow"
   bash:
     "rm -rf *": "ask"
     "sudo *": "deny"


### PR DESCRIPTION
## Summary

Updates agent permission configurations (`openagent.md` and `opencoder.md`) to add `question: "allow"`, enabling agents to use the built-in OpenCode question functionality to ask clarifying questions.

## Why This Matters

- **Session continuity:** Instead of ending a conversation with a question (which terminates the session), agents can now ask questions inline, keeping the session intact for follow-up answers.
- **Cost savings for metered LLM users:** This is especially beneficial for users on GitHub Copilot, or any other LLM provider where each request is counted. Without this change, a session ending with a question forces the user to consume another request just to answer it. With this change, the question and answer happen within the same session — no extra request needed.

## Type of Change
- [x] Refactoring

## Changes
- `.opencode/agent/core/openagent.md` — Added `question: "allow"` permission
- `.opencode/agent/core/opencoder.md` — Added `question: "allow"` permission

## Checklist
- [x] Tests pass locally
- [x] Follows [CONTRIBUTING.md](docs/contributing/CONTRIBUTING.md)

---

**Note:** Registry validation and smoke tests will run automatically.