### PR TITLE
fix: imports to use ES module syntax

### DIFF
--- a/.opencode/skills/task-management/scripts/task-cli.ts
+++ b/.opencode/skills/task-management/scripts/task-cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env npx ts-node
+/// <reference types="node" />
 /**
  * Task Management CLI
  *
@@ -19,8 +20,8 @@
  *   .tmp/tasks/completed/{feature-slug}/
  */
 
-const fs = require('fs');
-const path = require('path');
+import * as fs from "node:fs";
+import * as path from "node:path";
 
 // Find project root (look for .git or package.json)
 function findProjectRoot(): string {


### PR DESCRIPTION
## Description

The CLI error came from two things:
- the script was written like a Node CLI (require, process) but the repo TypeScript config didn’t expose Node globals/types for that file
- cmdComplete had a control-flow typing issue, so TypeScript still saw subtask as possibly undefined
Why the fix was necessary:
- without it, the task-management tool itself couldn’t compile, so we couldn’t mark tasks complete or ask for the next ready tasks
- fixing the tool restored the workflow/tracking layer, which we’re actively using to execute the feature safely

## Type of Change
- [ ] New feature (agent, command, tool)
- [X] Bug fix
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/CD

## Checklist
- [X] Tests pass locally
- [ ] Documentation updated (if needed)
- [X] Follows [CONTRIBUTING.md](docs/contributing/CONTRIBUTING.md)