### PR TITLE
fix: skip node_modules in updater markdown and shell scans

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -242,7 +242,7 @@ update_all_components() {
         else
             failed=$((failed + 1))
         fi
-    done < <(find "$install_dir" -name "*.md" -type f -print0)
+    done < <(find "$install_dir" -name "*.md" -type f -not -path "*/node_modules/*" -print0)
 
     # Update TypeScript files
     while IFS= read -r -d '' file; do
@@ -260,7 +260,7 @@ update_all_components() {
         else
             failed=$((failed + 1))
         fi
-    done < <(find "$install_dir" -name "*.sh" -type f -print0)
+    done < <(find "$install_dir" -name "*.sh" -type f -not -path "*/node_modules/*" -print0)
 
     print_info "Updated: $updated file(s), failed: $failed file(s)"
 }


### PR DESCRIPTION
## Summary
- Exclude `node_modules` from markdown and shell-file update sweeps in `update.sh` so dependency directories are skipped.
- This addresses issue #308, where updates were needlessly failing on `node_modules/*/README.md` and `.sh` files.

## Changes
- Add `-not -path "*/node_modules/*"` to the `find` loop for `*.md` files.
- Add `-not -path "*/node_modules/*"` to the `find` loop for `*.sh` files.

## Testing
- `bash -n update.sh`
- Fixture test: created a synthetic `.opencode` install dir with files under `normal/` and `node_modules/`; verified updater only attempts non-`node_modules` files.
- `npm test -- --passWithNoTests` (local environment: missing `tsx`)
- `cd evals/framework && npm test -- --passWithNoTests` (local environment: missing `vitest`)
- `ruff check .` (reports existing baseline errors in `scripts/registry/fix-registry.py`, pre-existing)

## Verification
- Independent pre-flight review (`requesting-code-review` equivalent) returned:
  - `passed: true`
  - no security concerns
  - no logic errors

Closes #308
