### PR TITLE
feat(nix): add native flake support with automated lock updates

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,57 @@
+name: Update Flake Lock
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-flake-lock
+  cancel-in-progress: false
+
+jobs:
+  update-flake-lock:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Update flake.lock
+        run: nix flake update
+
+      - name: Validate flake
+        run: nix flake check
+
+      - name: Test build
+        run: nix build .#default
+
+      - name: Commit flake.lock changes
+        run: |
+          if git diff --quiet -- flake.lock; then
+            echo "No flake.lock changes detected"
+            exit 0
+          fi
+
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add flake.lock
+          git commit -m "chore(nix): update flake.lock [skip ci]"
+          git push
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Flake Lock Update" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ flake update attempted" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ flake check executed" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ build executed" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -205,45 +205,22 @@ Add a login endpoint
 
 ---
 
-## For Nix Users: Installing With Flake Module
+## For Nix Users
 
-If you use Nix, you can install OAC through this repository's built-in flake module.
+If you use Nix, OAC includes a Home Manager flake module:
 
 ```nix
 {
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    home-manager.url = "github:nix-community/home-manager";
-    home-manager.inputs.nixpkgs.follows = "nixpkgs";
-
-    oac.url = "github:darrenhinde/OpenAgentsControl";
-  };
-
-  outputs = { nixpkgs, home-manager, oac, ... }: {
-    homeConfigurations.my-user = home-manager.lib.homeManagerConfiguration {
-      pkgs = import nixpkgs { system = "x86_64-linux"; };
-      modules = [
-        oac.homeManagerModules.default
-        {
-          programs.opencode = {
-            enable = true;
-            oac = {
-              enable = true;
-              profile = "developer"; # essential|developer|business|full|advanced
-            };
-          };
-        }
-      ];
-    };
+  programs.opencode.oac = {
+    enable = true;
+    profile = "developer";
   };
 }
 ```
 
-Apply with Home Manager:
+Import `oac.homeManagerModules.default`, then apply with `home-manager switch --flake .#my-user`.
 
-```bash
-home-manager switch --flake .#my-user
-```
+For the full setup, available `programs.opencode.oac.*` options, context reference behavior, bootstrap files, and built-in permission settings, see [docs/getting-started/nix-home-manager.md](docs/getting-started/nix-home-manager.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,48 @@ Add a login endpoint
 
 ---
 
+## For Nix Users: Installing With Flake Module
+
+If you use Nix, you can install OAC through this repository's built-in flake module.
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+
+    oac.url = "github:darrenhinde/OpenAgentsControl";
+  };
+
+  outputs = { nixpkgs, home-manager, oac, ... }: {
+    homeConfigurations.my-user = home-manager.lib.homeManagerConfiguration {
+      pkgs = import nixpkgs { system = "x86_64-linux"; };
+      modules = [
+        oac.homeManagerModules.default
+        {
+          programs.opencode = {
+            enable = true;
+            oac = {
+              enable = true;
+              profile = "developer"; # essential|developer|business|full|advanced
+            };
+          };
+        }
+      ];
+    };
+  };
+}
+```
+
+Apply with Home Manager:
+
+```bash
+home-manager switch --flake .#my-user
+```
+
+---
+
 ## 💡 The Context System: Your Secret Weapon
 
 **The problem with AI code:** It doesn't match your patterns. You spend hours refactoring.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Welcome to the OpenAgents Control documentation! This directory contains all doc
 
 - **[Installation Guide](getting-started/installation.md)** - Complete installation guide with collision handling
 - **[Collision Handling](getting-started/collision-handling.md)** - Quick reference for install script collision strategies
+- **[Nix Home Manager Guide](getting-started/nix-home-manager.md)** - Install OAC with the flake module and configure `programs.opencode.oac`
 
 ### Features
 
@@ -50,7 +51,8 @@ docs/
 ├── README.md                           # This file
 ├── getting-started/
 │   ├── installation.md                 # Installation guide
-│   └── collision-handling.md           # Collision handling reference
+│   ├── collision-handling.md           # Collision handling reference
+│   └── nix-home-manager.md             # Nix/Home Manager flake module guide
 ├── features/
 │   ├── system-builder/
 │   │   ├── README.md                   # System builder quick start
@@ -69,6 +71,9 @@ docs/
 
 **...install OpenAgents Control**
 → [Installation Guide](getting-started/installation.md)
+
+**...install OpenAgents Control with Nix/Home Manager**
+→ [Nix Home Manager Guide](getting-started/nix-home-manager.md)
 
 **...understand collision handling**
 → [Collision Handling](getting-started/collision-handling.md)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,6 +2,8 @@
 
 Complete guide to installing OpenAgents Control components using the automated installer script.
 
+> Use Nix/Home Manager instead? See the [Nix Home Manager Guide](./nix-home-manager.md).
+
 ---
 
 ## Quick Start

--- a/docs/getting-started/nix-home-manager.md
+++ b/docs/getting-started/nix-home-manager.md
@@ -1,0 +1,336 @@
+# OpenAgents Control with Nix Home Manager
+
+Use this guide if you want to install OpenAgents Control through the repository's built-in flake module instead of the shell installer.
+
+## When to use this
+
+This setup is a good fit if you already manage your OpenCode configuration with Nix and want OAC installation to be reproducible.
+
+If you do **not** already use Nix or Home Manager, the standard installer is simpler:
+
+- [Main README quick start](../../README.md#-quick-start)
+- [Installation Guide](./installation.md)
+
+---
+
+## Quick start
+
+Add OAC as a flake input and import its Home Manager module:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+
+    oac.url = "github:darrenhinde/OpenAgentsControl";
+  };
+
+  outputs = { nixpkgs, home-manager, oac, ... }: {
+    homeConfigurations.my-user = home-manager.lib.homeManagerConfiguration {
+      pkgs = import nixpkgs { system = "x86_64-linux"; };
+      modules = [
+        oac.homeManagerModules.default
+        {
+          programs.opencode.oac = {
+            enable = true;
+            profile = "developer";
+          };
+        }
+      ];
+    };
+  };
+}
+```
+
+Apply the configuration:
+
+```bash
+home-manager switch --flake .#my-user
+```
+
+---
+
+## What the module does by default
+
+When you enable `programs.opencode.oac`, the module:
+
+- imports `oac.homeManagerModules.default`
+- enables `programs.opencode` automatically
+- uses this flake's source tree by default
+- rewrites `.opencode/context` references in installed files by default
+- points rewritten context references at the pinned source-backed context path by default
+- installs the bootstrap context files required for reliable context discovery
+- enables a default set of OpenCode permission rules for OAC context access and project `.tmp` access
+
+---
+
+## Common configuration
+
+### Minimal configuration
+
+```nix
+{
+  programs.opencode.oac = {
+    enable = true;
+    profile = "developer";
+  };
+}
+```
+
+### Add extra components
+
+```nix
+{
+  programs.opencode.oac = {
+    enable = true;
+    profile = "developer";
+    components = [
+      "agent:openagent"
+      "command:add-context"
+      "context:core/*"
+    ];
+  };
+}
+```
+
+### Install only custom-selected components
+
+Set `profile = null` to skip profile presets and install only the components you specify:
+
+```nix
+{
+  programs.opencode.oac = {
+    enable = true;
+    profile = null;
+    components = [
+      "agent:openagent"
+      "command:add-context"
+    ];
+  };
+}
+```
+
+### Exclude components from a profile
+
+```nix
+{
+  programs.opencode.oac = {
+    enable = true;
+    profile = "full";
+    excludeComponents = [
+      "plugin:notify"
+    ];
+  };
+}
+```
+
+---
+
+## Important options
+
+### Core options
+
+| Option | Default | What it does |
+| --- | --- | --- |
+| `enable` | `false` | Turns on OAC installation through Home Manager. |
+| `enableOpencode` | `true` | Enables `programs.opencode` automatically when OAC is enabled. |
+| `source` | flake source | Uses a custom OAC source tree containing `registry.json` and `.opencode/`. |
+| `profile` | `"developer"` | Installs a preset profile: `essential`, `developer`, `business`, `full`, or `advanced`. Use `null` for custom-only selection. |
+| `components` | `[]` | Adds extra registry components on top of the selected profile. |
+| `excludeComponents` | `[]` | Removes specific components after profile and dependency expansion. |
+| `includeDependencies` | `true` | Includes transitive dependencies from `registry.json`. |
+
+### Installation layout options
+
+| Option | Default | What it does |
+| --- | --- | --- |
+| `targetRoot` | `"opencode"` | Base directory under `$XDG_CONFIG_HOME` where files are installed. |
+| `layout.agent` | `"agent"` | Destination directory name for agent files. |
+| `layout.command` | `"command"` | Destination directory name for command files. |
+| `layout.context` | `"context"` | Destination directory name for context files. |
+| `layout.tool` | `"tool"` | Destination directory name for tool files. |
+| `layout.plugin` | `"plugin"` | Destination directory name for plugins. |
+| `layout.skills` | `"skills"` | Destination directory name for skills. |
+| `layout.config` | `""` | Destination directory for files that are not under `.opencode/`. Empty keeps them at the target root. |
+| `pathOverrides` | `{}` | Overrides exact generated destination paths for specific source files. |
+| `force` | `false` | Sets `xdg.configFile.<name>.force` for generated files. |
+
+### Context and rewrite options
+
+| Option | Default | What it does |
+| --- | --- | --- |
+| `rewriteContextReferences` | `true` | Rewrites `.opencode/context` references inside installed files. |
+| `contextReferencePath` | `null` | Overrides the path used for rewritten context references. |
+| `extraFiles` | `{}` | Adds extra files under `targetRoot` after generated profile files. |
+| `overrides` | `{}` | Replaces final installed files under `targetRoot` after all generation steps. |
+
+### Permission and advanced options
+
+| Option | Default | What it does |
+| --- | --- | --- |
+| `enableBuiltinPermissions` | `true` | Enables the module's built-in OpenCode permission rules. |
+| `allowOacContextRead` | `true` | Allows reads to the OAC context reference path, denies edits there, and requires approval for matching bash commands. |
+| `allowTmpDirFullAccess` | `true` | Allows reads, edits, and built-in `ls` / `mkdir` patterns for project `.tmp`. |
+| `installAdditionalPaths` | `false` | Installs profile `additionalPaths` recursively as XDG config files. |
+| `additionalPathsPrefix` | `"additional"` | Target prefix used when `installAdditionalPaths = true`. |
+
+---
+
+## Bootstrap context files
+
+These bootstrap files are installed unless explicitly excluded:
+
+- `$XDG_CONFIG_HOME/opencode/context/navigation.md`
+- `$XDG_CONFIG_HOME/opencode/context/core/config/paths.json`
+
+These are canonical discovery files and do **not** follow `pathOverrides`.
+
+---
+
+## Context reference behavior
+
+By default, `contextReferencePath = null` resolves to the pinned source-backed context directory:
+
+```nix
+{
+  programs.opencode.oac.contextReferencePath = null;
+}
+```
+
+That means rewritten references point at the flake source / Nix store path for `.opencode/context`, not the Home Manager symlink tree. This avoids symlink traversal issues during context discovery.
+
+If you want rewritten references to point at your config directory instead:
+
+```nix
+{ config, ... }:
+{
+  programs.opencode.oac.contextReferencePath = "${config.xdg.configHome}/opencode/context";
+}
+```
+
+If you want to keep installed file contents unchanged, disable rewriting:
+
+```nix
+{
+  programs.opencode.oac.rewriteContextReferences = false;
+}
+```
+
+---
+
+## Built-in permissions
+
+The module can install a default permission policy for OpenCode.
+
+### Default behavior
+
+- `enableBuiltinPermissions = true`
+- `allowOacContextRead = true`
+- `allowTmpDirFullAccess = true`
+
+This means:
+
+- the OAC context reference path is readable
+- edits to that context reference path are denied
+- bash commands targeting that path require approval
+- project `.tmp` reads and edits are allowed
+- built-in `ls` and `mkdir` patterns for `.tmp` are allowed
+
+### Example: customize permissions
+
+```nix
+{
+  programs.opencode.oac = {
+    enable = true;
+    enableBuiltinPermissions = true;
+    allowOacContextRead = true;
+    allowTmpDirFullAccess = false;
+  };
+}
+```
+
+### Example: disable module-managed permissions completely
+
+```nix
+{
+  programs.opencode.oac = {
+    enable = true;
+    enableBuiltinPermissions = false;
+  };
+}
+```
+
+Use that if you want to manage OpenCode permissions yourself through `programs.opencode.settings`.
+
+---
+
+## Path customization examples
+
+### Change the install root
+
+```nix
+{
+  programs.opencode.oac.targetRoot = "opencode-team";
+}
+```
+
+This installs files under `$XDG_CONFIG_HOME/opencode-team/...`.
+
+### Override a generated file path
+
+```nix
+{
+  programs.opencode.oac.pathOverrides = {
+    ".opencode/agent/core/openagent.md" = "agents/openagent.md";
+  };
+}
+```
+
+### Add your own files after profile generation
+
+```nix
+{
+  programs.opencode.oac.extraFiles = {
+    "context/project-intelligence/technical-domain.md" = ./technical-domain.md;
+  };
+}
+```
+
+### Replace a generated file entirely
+
+```nix
+{
+  programs.opencode.oac.overrides = {
+    "agent/core/openagent.md" = ./openagent.md;
+  };
+}
+```
+
+---
+
+## Notes about the `advanced` profile
+
+The `advanced` profile can reference `additionalPaths` entries from `registry.json`.
+
+Those are **not** installed by default, which matches the current shell installer behavior. To include them:
+
+```nix
+{
+  programs.opencode.oac = {
+    enable = true;
+    profile = "advanced";
+    installAdditionalPaths = true;
+  };
+}
+```
+
+---
+
+## Related docs
+
+- [Main README](../../README.md)
+- [Installation Guide](./installation.md)
+- [Documentation Index](../README.md)
+- [OpenCode CLI Docs](https://opencode.ai/docs)

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777771152,
-        "narHash": "sha256-+J0PGlJpLvo1ukmHM0ksI8PtBDwMCYyh87rbs86F0/c=",
+        "lastModified": 1777852249,
+        "narHash": "sha256-XdbGWnFlX4McOEG5NioVsp35Ic6XL/rXnp8as71cu6o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9c9fc9368a6d9e698d03d3780d3b930ebc060334",
+        "rev": "c909892de502b4de9e92838a503c09a9c8ebe4aa",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777852249,
-        "narHash": "sha256-XdbGWnFlX4McOEG5NioVsp35Ic6XL/rXnp8as71cu6o=",
+        "lastModified": 1778444552,
+        "narHash": "sha256-f18pIiR9q/p1vHY93gmAum7aHhQOG49oGvAB9+lptRo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c909892de502b4de9e92838a503c09a9c8ebe4aa",
+        "rev": "dcebe66f958673729896eec2de4abfd86ef22d21",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777578337,
-        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778444552,
-        "narHash": "sha256-f18pIiR9q/p1vHY93gmAum7aHhQOG49oGvAB9+lptRo=",
+        "lastModified": 1779075347,
+        "narHash": "sha256-ZqttlFPw0meQMdABi8/vgle14OWQ3FkIqUkb4/Mrc+0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "dcebe66f958673729896eec2de4abfd86ef22d21",
+        "rev": "08c9d01457badce151aa4a983c475042d9dec018",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779678629,
-        "narHash": "sha256-gHcIFg0mm+KFsg7iZQt67kni3+qR5U3PhEC9P7vKlZ4=",
+        "lastModified": 1780099287,
+        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "612bbe3b405ad5f71d7bf9edecc04b678a061652",
+        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779508470,
-        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "29916453413845e54a65b8a1cf996842300cd299",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779103424,
-        "narHash": "sha256-hBYJz5jnRDjACPrwdD064zwMW+s5bdNlG/lNQipLhgM=",
+        "lastModified": 1779678629,
+        "narHash": "sha256-gHcIFg0mm+KFsg7iZQt67kni3+qR5U3PhEC9P7vKlZ4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "dd71501fb7005264feb4de78444a2e1518cd4f66",
+        "rev": "612bbe3b405ad5f71d7bf9edecc04b678a061652",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1779508470,
+        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "29916453413845e54a65b8a1cf996842300cd299",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782103446,
-        "narHash": "sha256-+vMR3KPBVoY9nJrQI9qje5H1vmv51dJgMYkUuYimtJg=",
+        "lastModified": 1782702263,
+        "narHash": "sha256-8/MG4Su7PhnynrmsVO61IeAfrK7GuUEu+E+gwbhy1QQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d8dac1f668fd861369571be3678ec75b1573e7e3",
+        "rev": "789a35fbdeb3c46b260096daa0b321c11be527ea",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782702263,
-        "narHash": "sha256-8/MG4Su7PhnynrmsVO61IeAfrK7GuUEu+E+gwbhy1QQ=",
+        "lastModified": 1783222121,
+        "narHash": "sha256-E/ElL373TO8lQ2aMvYyzN+k4xkVaUGoRqoa8AtM71tI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "789a35fbdeb3c46b260096daa0b321c11be527ea",
+        "rev": "a1645f40777620c4bd2b6d854b290c2fc354a266",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782467914,
-        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781497404,
-        "narHash": "sha256-9GAF8sSsnkyCVCWkomXR0T+zdSxyUlfPt6neQidimdg=",
+        "lastModified": 1782103446,
+        "narHash": "sha256-+vMR3KPBVoY9nJrQI9qje5H1vmv51dJgMYkUuYimtJg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1285cd3d6882a9847f2d56ed5541b3350c8a6162",
+        "rev": "d8dac1f668fd861369571be3678ec75b1573e7e3",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780099287,
-        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
+        "lastModified": 1780885330,
+        "narHash": "sha256-aMA5oAq2Iv467U9s8YOb50DYQT9w0WJbyWqwlzHuLMs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
+        "rev": "4fe95527cbe952713318ada8a4d122e1a6ab120f",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777771152,
+        "narHash": "sha256-+J0PGlJpLvo1ukmHM0ksI8PtBDwMCYyh87rbs86F0/c=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "9c9fc9368a6d9e698d03d3780d3b930ebc060334",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780885330,
-        "narHash": "sha256-aMA5oAq2Iv467U9s8YOb50DYQT9w0WJbyWqwlzHuLMs=",
+        "lastModified": 1781497404,
+        "narHash": "sha256-9GAF8sSsnkyCVCWkomXR0T+zdSxyUlfPt6neQidimdg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4fe95527cbe952713318ada8a4d122e1a6ab120f",
+        "rev": "1285cd3d6882a9847f2d56ed5541b3350c8a6162",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779075347,
-        "narHash": "sha256-ZqttlFPw0meQMdABi8/vgle14OWQ3FkIqUkb4/Mrc+0=",
+        "lastModified": 1779103424,
+        "narHash": "sha256-hBYJz5jnRDjACPrwdD064zwMW+s5bdNlG/lNQipLhgM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "08c9d01457badce151aa4a983c475042d9dec018",
+        "rev": "dd71501fb7005264feb4de78444a2e1518cd4f66",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783222121,
-        "narHash": "sha256-E/ElL373TO8lQ2aMvYyzN+k4xkVaUGoRqoa8AtM71tI=",
+        "lastModified": 1783823409,
+        "narHash": "sha256-OI4IkRjRXa1e7hYmCGJDPDq5H/kPwhsyoS80cNUF9fI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a1645f40777620c4bd2b6d854b290c2fc354a266",
+        "rev": "7566825d4652a1b885bd4ce65bd9e8def432fec9",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783224372,
-        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783823409,
-        "narHash": "sha256-OI4IkRjRXa1e7hYmCGJDPDq5H/kPwhsyoS80cNUF9fI=",
+        "lastModified": 1784489491,
+        "narHash": "sha256-j9maqjx1T8+ljAVntAdSI5hSGCm77QNZz64JF1rJNu0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7566825d4652a1b885bd4ce65bd9e8def432fec9",
+        "rev": "3139deb8cafbe73b39b24451255b2fdd3426077e",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783776592,
-        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787540599,
-        "narHash": "sha256-MHwk52ty3NsLhq9a1IbIfBJZlCUJIdiUYFo52JLK9hY=",
+        "lastModified": 1788146656,
+        "narHash": "sha256-XmJmvk9rytTb7dCotO/aqR+YysB8HOqnprlOdv+LAF4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "03f4cd46bc1dd4f3a96da778d2ce9f7ce39dd450",
+        "rev": "82c265faf4e3161d6015db07c9b0f1ee36a9029b",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787360063,
-        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
+        "lastModified": 1788039129,
+        "narHash": "sha256-pa4Q0qErvCvzCaaUph7Sm37RhR4xvPrYI8Lgz6k85+A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
+        "rev": "d2f67949798825fe853f7c5d0492b8bf016d3f88",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784489491,
-        "narHash": "sha256-j9maqjx1T8+ljAVntAdSI5hSGCm77QNZz64JF1rJNu0=",
+        "lastModified": 1785119578,
+        "narHash": "sha256-3VMVuOJ6fK+RNOXVmqusqUwQ1sDfPeddNKaM2JR/4Y0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3139deb8cafbe73b39b24451255b2fdd3426077e",
+        "rev": "e83dffa86cccb6237fe194d4eeb47f41557749d1",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784356753,
-        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "lastModified": 1785090369,
+        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "rev": "624af665418d3c65d544145b4d34ad696439570e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785531816,
-        "narHash": "sha256-vkMnV0JIyw+g/NmcfoajlGaAO+9a0ezia+FZohQJrik=",
+        "lastModified": 1786286733,
+        "narHash": "sha256-7dN93WKkEERgutPtTjK7SY3ZarO2LAU33A1+vKu+7cc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bf9ce9fec78f95f374e8dd3b503863a3ec128ebe",
+        "rev": "367f7ef80856d18438953d54dda235d42a46ba31",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785571196,
-        "narHash": "sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw=",
+        "lastModified": 1786106723,
+        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "148bab9c1c3c53136ecb44a6ea356a0ed5b39b06",
+        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788146656,
-        "narHash": "sha256-XmJmvk9rytTb7dCotO/aqR+YysB8HOqnprlOdv+LAF4=",
+        "lastModified": 1788651960,
+        "narHash": "sha256-v9wJd32eZ2bvhBzVOd7TIjLQd011P7nwOhjKtWlci5I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "82c265faf4e3161d6015db07c9b0f1ee36a9029b",
+        "rev": "2c0350c759688177331b8f5242311fae8877bdb3",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788039129,
-        "narHash": "sha256-pa4Q0qErvCvzCaaUph7Sm37RhR4xvPrYI8Lgz6k85+A=",
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2f67949798825fe853f7c5d0492b8bf016d3f88",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785119578,
-        "narHash": "sha256-3VMVuOJ6fK+RNOXVmqusqUwQ1sDfPeddNKaM2JR/4Y0=",
+        "lastModified": 1785531816,
+        "narHash": "sha256-vkMnV0JIyw+g/NmcfoajlGaAO+9a0ezia+FZohQJrik=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e83dffa86cccb6237fe194d4eeb47f41557749d1",
+        "rev": "bf9ce9fec78f95f374e8dd3b503863a3ec128ebe",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785090369,
-        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
+        "lastModified": 1785571196,
+        "narHash": "sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "624af665418d3c65d544145b4d34ad696439570e",
+        "rev": "148bab9c1c3c53136ecb44a6ea356a0ed5b39b06",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786286733,
-        "narHash": "sha256-7dN93WKkEERgutPtTjK7SY3ZarO2LAU33A1+vKu+7cc=",
+        "lastModified": 1786929086,
+        "narHash": "sha256-kzpwMyT7i2fTQ41tf/WlsIHuJtf3e0leRBEPkBhUzBY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "367f7ef80856d18438953d54dda235d42a46ba31",
+        "rev": "aac4965ddb7ea2ff0f3cadd9502c7042b7aa07ba",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786106723,
-        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
+        "lastModified": 1786862985,
+        "narHash": "sha256-FBJRXmbGXiSUDvYEbfLYRkckayyZ6SK1UEqhCrIZ2Cs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
+        "rev": "e5bdc4a41d4c072fe1e3787eaa0320a384741d44",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786929086,
-        "narHash": "sha256-kzpwMyT7i2fTQ41tf/WlsIHuJtf3e0leRBEPkBhUzBY=",
+        "lastModified": 1787540599,
+        "narHash": "sha256-MHwk52ty3NsLhq9a1IbIfBJZlCUJIdiUYFo52JLK9hY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "aac4965ddb7ea2ff0f3cadd9502c7042b7aa07ba",
+        "rev": "03f4cd46bc1dd4f3a96da778d2ce9f7ce39dd450",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786862985,
-        "narHash": "sha256-FBJRXmbGXiSUDvYEbfLYRkckayyZ6SK1UEqhCrIZ2Cs=",
+        "lastModified": 1787360063,
+        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e5bdc4a41d4c072fe1e3787eaa0320a384741d44",
+        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "Nix flake module for OpenAgentsControl (OAC) + Home Manager OpenCode";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      ...
+    }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forEachSystem =
+        f:
+        builtins.listToAttrs (
+          builtins.map (system: {
+            name = system;
+            value = f system;
+          }) systems
+        );
+    in
+    {
+      homeManagerModules = {
+        oac = import ./nix/modules/home-manager/oac.nix { oacSource = self; };
+        default = self.homeManagerModules.oac;
+      };
+
+      packages = forEachSystem (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.writeText "oac-flake-module" "OpenAgentsControl Home Manager module";
+        }
+      );
+    };
+}

--- a/nix/modules/home-manager/oac.nix
+++ b/nix/modules/home-manager/oac.nix
@@ -1,9 +1,12 @@
-{ oacSource ? null }:
+{
+  oacSource ? null,
+}:
 { lib, config, ... }:
 let
   inherit (lib)
     mkEnableOption
     mkIf
+    mkMerge
     mkOption
     mkDefault
     types
@@ -16,10 +19,7 @@ let
   source = if cfg.source != null then cfg.source else oacSource;
 
   registry =
-    if source == null then
-      null
-    else
-      builtins.fromJSON (builtins.readFile "${source}/registry.json");
+    if source == null then null else builtins.fromJSON (builtins.readFile "${source}/registry.json");
 
   components = if registry == null then { } else registry.components;
   contexts = components.contexts or [ ];
@@ -66,7 +66,9 @@ let
   findById =
     items: id:
     let
-      matches = builtins.filter (item: (item.id or null) == id || lib.elem id (item.aliases or [ ])) items;
+      matches = builtins.filter (
+        item: (item.id or null) == id || lib.elem id (item.aliases or [ ])
+      ) items;
     in
     if matches == [ ] then null else builtins.head matches;
 
@@ -75,7 +77,9 @@ let
     let
       pathMd = ".opencode/context/${id}.md";
       pathAsIs = ".opencode/context/${id}";
-      matches = builtins.filter (item: (item.path or "") == pathMd || (item.path or "") == pathAsIs) contexts;
+      matches = builtins.filter (
+        item: (item.path or "") == pathMd || (item.path or "") == pathAsIs
+      ) contexts;
     in
     if matches == [ ] then null else builtins.head matches;
 
@@ -103,10 +107,7 @@ let
       fullPrefix = ".opencode/context/${prefixWithSlash}";
       matches = builtins.filter (item: lib.hasPrefix fullPrefix (item.path or "")) contexts;
     in
-    builtins.map (
-      item:
-      "context:${stripMdSuffix (lib.removePrefix ".opencode/context/" item.path)}"
-    ) matches;
+    map (item: "context:${stripMdSuffix (lib.removePrefix ".opencode/context/" item.path)}") matches;
 
   expandSpec =
     spec:
@@ -129,9 +130,17 @@ let
       null;
 
   profileComponents = if selectedProfile == null then [ ] else selectedProfile.components or [ ];
-  profileAdditionalPaths = if selectedProfile == null then [ ] else selectedProfile.additionalPaths or [ ];
+  profileAdditionalPaths =
+    if selectedProfile == null then [ ] else selectedProfile.additionalPaths or [ ];
 
-  initialSpecs = lib.unique (lib.concatMap expandSpec (profileComponents ++ cfg.components));
+  bootstrapContextSpecs = [
+    "context:root-navigation"
+    "context:context-paths-config"
+  ];
+
+  initialSpecs = lib.unique (
+    lib.concatMap expandSpec (profileComponents ++ cfg.components ++ bootstrapContextSpecs)
+  );
 
   dependenciesFor =
     spec:
@@ -143,7 +152,10 @@ let
         let
           parsed = parseSpec dep;
         in
-        if parsed != null && parsed.type == "context" && hasWildcard dep then expandContextPattern parsed.id else [ dep ];
+        if parsed != null && parsed.type == "context" && hasWildcard dep then
+          expandContextPattern parsed.id
+        else
+          [ dep ];
     in
     lib.unique (lib.concatMap expandDependency dependencies);
 
@@ -165,23 +177,53 @@ let
         resolveAllDependencies (seen ++ [ current ]) (deps ++ rest);
 
   resolvedSpecs =
-    if cfg.includeDependencies then
-      resolveAllDependencies [ ] initialSpecs
-    else
-      initialSpecs;
+    if cfg.includeDependencies then resolveAllDependencies [ ] initialSpecs else initialSpecs;
 
   finalSpecs = builtins.filter (spec: !(lib.elem spec cfg.excludeComponents)) resolvedSpecs;
 
-  sourceFiles =
-    lib.unique (
-      lib.concatMap (
-        spec:
-        let
-          component = resolveComponent spec;
-        in
-        if component == null then [ ] else if component ? files then component.files else [ component.path ]
-      ) finalSpecs
-    );
+  requiredBootstrapSpecs = builtins.filter (
+    spec: !(lib.elem spec cfg.excludeComponents)
+  ) bootstrapContextSpecs;
+
+  bootstrapResolvedComponents = map (spec: {
+    inherit spec;
+    component = resolveComponent spec;
+  }) requiredBootstrapSpecs;
+
+  missingBootstrapComponents = builtins.filter (
+    entry: entry.component == null
+  ) bootstrapResolvedComponents;
+
+  bootstrapExpectedSourceFiles = lib.unique (
+    lib.concatMap (
+      entry:
+      if entry.component == null then
+        [ ]
+      else if entry.component ? files then
+        entry.component.files
+      else
+        [ entry.component.path ]
+    ) bootstrapResolvedComponents
+  );
+
+  sourceFiles = lib.unique (
+    lib.concatMap (
+      spec:
+      let
+        component = resolveComponent spec;
+      in
+      if component == null then
+        [ ]
+      else if component ? files then
+        component.files
+      else
+        [ component.path ]
+    ) finalSpecs
+  );
+
+  missingBootstrapSourcePaths = builtins.filter (
+    path: !(builtins.pathExists "${source}/${path}")
+  ) bootstrapExpectedSourceFiles;
 
   layoutMap = {
     agent = cfg.layout.agent;
@@ -193,18 +235,19 @@ let
     config = cfg.layout.config;
   };
 
-  mapRelativePath =
+  mapSourceRelativePath =
     sourcePath:
-    if builtins.hasAttr sourcePath cfg.pathOverrides then
-      builtins.getAttr sourcePath cfg.pathOverrides
-    else if lib.hasPrefix ".opencode/" sourcePath then
+    if lib.hasPrefix ".opencode/" sourcePath then
       let
         rel = lib.removePrefix ".opencode/" sourcePath;
         segments = lib.splitString "/" rel;
         headSegment = builtins.head segments;
         tailSegments = builtins.tail segments;
         mappedHead =
-          if builtins.hasAttr headSegment layoutMap then builtins.getAttr headSegment layoutMap else headSegment;
+          if builtins.hasAttr headSegment layoutMap then
+            builtins.getAttr headSegment layoutMap
+          else
+            headSegment;
         mappedSegments = if mappedHead == "" then tailSegments else [ mappedHead ] ++ tailSegments;
       in
       lib.concatStringsSep "/" mappedSegments
@@ -213,15 +256,71 @@ let
     else
       "${cfg.layout.config}/${sourcePath}";
 
-  withTargetRoot =
-    rel:
-    if cfg.targetRoot == "" then
-      rel
+  mapRelativePath =
+    sourcePath:
+    if builtins.hasAttr sourcePath cfg.pathOverrides then
+      builtins.getAttr sourcePath cfg.pathOverrides
     else
-      "${cfg.targetRoot}/${rel}";
+      mapSourceRelativePath sourcePath;
+
+  withTargetRoot = rel: if cfg.targetRoot == "" then rel else "${cfg.targetRoot}/${rel}";
 
   contextReferencePath =
-    if cfg.contextReferencePath != null then cfg.contextReferencePath else "${config.xdg.configHome}/${withTargetRoot cfg.layout.context}";
+    if cfg.contextReferencePath != null then
+      cfg.contextReferencePath
+    else
+      "${source}/.opencode/context";
+
+  contextReferencePathForPermissions = builtins.unsafeDiscardStringContext contextReferencePath;
+
+  expandPermissionPaths = path: [
+    path
+    "${path}/**"
+  ];
+
+  oacContextPermissionPaths = lib.unique (
+    lib.concatMap expandPermissionPaths [
+      contextReferencePathForPermissions
+    ]
+  );
+
+  oacContextBashPatterns = lib.unique [
+    "* ${contextReferencePathForPermissions}*"
+  ];
+
+  tmpDirPermissionPaths = expandPermissionPaths ".tmp";
+
+  tmpDirBashPatterns = [
+    "ls .tmp*"
+    "ls * .tmp*"
+    "ls \".tmp*"
+    "ls * \".tmp*"
+    "mkdir * tmp*"
+    "mkdir tmp*"
+    "mkdir \".tmp*"
+    "mkdir * \".tmp*"
+  ];
+
+  mkPermissionRules =
+    patterns: action:
+    builtins.listToAttrs (map (pattern: nameValuePair pattern (mkDefault action)) patterns);
+
+  contextDirectoryPermissionSettings = {
+    permission = {
+      external_directory = mkPermissionRules oacContextPermissionPaths "allow";
+      read = mkPermissionRules oacContextPermissionPaths "allow";
+      edit = mkPermissionRules oacContextPermissionPaths "deny";
+      bash = mkPermissionRules oacContextBashPatterns "ask";
+    };
+  };
+
+  tmpDirFullAccessSettings = {
+    permission = {
+      read = mkPermissionRules tmpDirPermissionPaths "allow";
+      edit = mkPermissionRules tmpDirPermissionPaths "allow";
+      bash = mkPermissionRules tmpDirBashPatterns "allow";
+    };
+  };
 
   rewriteContextRefs =
     text:
@@ -230,20 +329,22 @@ let
         [
           "@.opencode/context/"
           ".opencode/context"
+          "~/.config/opencode/context"
         ]
         [
           "@${contextReferencePath}/"
+          contextReferencePath
           contextReferencePath
         ]
         text
     else
       text;
 
-  mkGeneratedFileEntry =
-    sourcePath:
+  mkFileEntry =
+    pathMapper: sourcePath:
     let
       src = "${source}/${sourcePath}";
-      destRel = mapRelativePath sourcePath;
+      destRel = pathMapper sourcePath;
       key = withTargetRoot destRel;
       fileValue =
         if cfg.rewriteContextReferences then
@@ -257,7 +358,13 @@ let
     in
     nameValuePair key ({ force = cfg.force; } // fileValue);
 
-  generatedFileEntries = builtins.listToAttrs (builtins.map mkGeneratedFileEntry sourceFiles);
+  mkGeneratedFileEntry = mkFileEntry mapRelativePath;
+
+  mkBootstrapFileEntry = mkFileEntry mapSourceRelativePath;
+
+  generatedFileEntries = builtins.listToAttrs (map mkGeneratedFileEntry sourceFiles);
+
+  bootstrapFileEntries = builtins.listToAttrs (map mkBootstrapFileEntry bootstrapExpectedSourceFiles);
 
   additionalPaths = if cfg.installAdditionalPaths then profileAdditionalPaths else [ ];
 
@@ -267,10 +374,7 @@ let
       cleanRel = lib.removeSuffix "/" relPath;
       src = "${source}/${cleanRel}";
       destRel =
-        if cfg.additionalPathsPrefix == "" then
-          cleanRel
-        else
-          "${cfg.additionalPathsPrefix}/${cleanRel}";
+        if cfg.additionalPathsPrefix == "" then cleanRel else "${cfg.additionalPathsPrefix}/${cleanRel}";
       key = withTargetRoot destRel;
       base = {
         source = src;
@@ -280,16 +384,13 @@ let
     in
     nameValuePair key (base // recursiveAttrs);
 
-  additionalPathEntries = builtins.listToAttrs (builtins.map mkAdditionalPathEntry additionalPaths);
+  additionalPathEntries = builtins.listToAttrs (map mkAdditionalPathEntry additionalPaths);
 
   mkUserEntry =
     key: value:
-    nameValuePair
-      (withTargetRoot key)
-      (
-        { force = cfg.force; }
-        // (if lib.isPath value then { source = value; } else { text = value; })
-      );
+    nameValuePair (withTargetRoot key) (
+      { force = cfg.force; } // (if lib.isPath value then { source = value; } else { text = value; })
+    );
 
   extraFileEntries = mapAttrs' mkUserEntry cfg.extraFiles;
   overrideEntries = mapAttrs' mkUserEntry cfg.overrides;
@@ -306,6 +407,45 @@ in
       description = "Enable `programs.opencode` automatically when OAC is enabled.";
     };
 
+    enableBuiltinPermissions = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Enable OAC's built-in OpenCode permission rules.
+
+        When enabled, this module can add the OAC context read policy and the project `.tmp`
+        access policy according to `allowOacContextRead` and `allowTmpDirFullAccess`. Set this
+        to `false` to disable all permission rules generated by this module while still installing
+        OAC files and preserving any permission settings you define directly in
+        `programs.opencode.settings`.
+      '';
+    };
+
+    allowOacContextRead = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Add default OpenCode permission rules for the OAC context reference path.
+
+        This allows reads to the pinned OAC context path while denying edits and requiring
+        `ask` approval for bash commands that target that path. Set to `false` to disable
+        this policy. This option only has an effect when `enableBuiltinPermissions` is true.
+      '';
+    };
+
+    allowTmpDirFullAccess = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Add default OpenCode permission rules for the project `.tmp` directory.
+
+        This allows reads and edits for both `.tmp` and `.tmp/**` and adds allow rules for the
+        built-in `ls` and `mkdir` command patterns used to inspect or create `.tmp` directories.
+        Set to `false` to disable this policy. This option only has an effect when
+        `enableBuiltinPermissions` is true.
+      '';
+    };
+
     source = mkOption {
       type = types.nullOr types.path;
       default = null;
@@ -317,13 +457,15 @@ in
     };
 
     profile = mkOption {
-      type = types.nullOr (types.enum [
-        "essential"
-        "developer"
-        "business"
-        "full"
-        "advanced"
-      ]);
+      type = types.nullOr (
+        types.enum [
+          "essential"
+          "developer"
+          "business"
+          "full"
+          "advanced"
+        ]
+      );
       default = "developer";
       description = ''
         Profile to install from OAC `registry.json`.
@@ -438,7 +580,8 @@ in
       description = ''
         Explicit path used for rewritten context references.
 
-        When null, defaults to `${config.xdg.configHome}/<targetRoot>/<layout.context>`.
+        When null, defaults to the pinned OAC source context directory in the Nix store.
+        This keeps context discovery on immutable real paths instead of Home Manager symlinks.
       '';
     };
 
@@ -496,22 +639,39 @@ in
       {
         assertion = missingFiles == [ ];
         message =
-          "Some resolved OAC files were not found in source: "
-          + lib.concatStringsSep ", " missingFiles;
+          "Some resolved OAC files were not found in source: " + lib.concatStringsSep ", " missingFiles;
+      }
+      {
+        assertion = missingBootstrapComponents == [ ];
+        message =
+          "Required bootstrap components could not be resolved from registry/source: "
+          + lib.concatStringsSep ", " (map (entry: entry.spec) missingBootstrapComponents);
+      }
+      {
+        assertion = missingBootstrapSourcePaths == [ ];
+        message =
+          "Resolved bootstrap components reference source paths that do not exist: "
+          + lib.concatStringsSep ", " missingBootstrapSourcePaths;
       }
     ];
 
     warnings =
       lib.optional
-        (
-          cfg.profile == "advanced"
-          && profileAdditionalPaths != [ ]
-          && !cfg.installAdditionalPaths
-        )
+        (cfg.profile == "advanced" && profileAdditionalPaths != [ ] && !cfg.installAdditionalPaths)
         "programs.opencode.oac.profile=advanced includes additionalPaths in registry.json, but installAdditionalPaths=false so they are skipped (matching install.sh behavior).";
 
     programs.opencode.enable = mkIf cfg.enableOpencode (mkDefault true);
 
-    xdg.configFile = generatedFileEntries // additionalPathEntries // extraFileEntries // overrideEntries;
+    programs.opencode.settings = mkMerge [
+      (mkIf (cfg.enableBuiltinPermissions && cfg.allowOacContextRead) contextDirectoryPermissionSettings)
+      (mkIf (cfg.enableBuiltinPermissions && cfg.allowTmpDirFullAccess) tmpDirFullAccessSettings)
+    ];
+
+    xdg.configFile =
+      generatedFileEntries
+      // bootstrapFileEntries
+      // additionalPathEntries
+      // extraFileEntries
+      // overrideEntries;
   };
 }

--- a/nix/modules/home-manager/oac.nix
+++ b/nix/modules/home-manager/oac.nix
@@ -1,0 +1,517 @@
+{ oacSource ? null }:
+{ lib, config, ... }:
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    mkDefault
+    types
+    nameValuePair
+    mapAttrs'
+    ;
+
+  cfg = config.programs.opencode.oac;
+
+  source = if cfg.source != null then cfg.source else oacSource;
+
+  registry =
+    if source == null then
+      null
+    else
+      builtins.fromJSON (builtins.readFile "${source}/registry.json");
+
+  components = if registry == null then { } else registry.components;
+  contexts = components.contexts or [ ];
+  profiles = if registry == null then { } else registry.profiles;
+
+  parseSpec =
+    spec:
+    let
+      match = builtins.match "([^:]+):(.+)" spec;
+    in
+    if match == null then
+      null
+    else
+      {
+        type = builtins.elemAt match 0;
+        id = builtins.elemAt match 1;
+      };
+
+  hasWildcard = spec: builtins.match ".*\*.*" spec != null;
+
+  toRegistryKey =
+    type:
+    if type == "agent" then
+      "agents"
+    else if type == "subagent" then
+      "subagents"
+    else if type == "command" then
+      "commands"
+    else if type == "tool" then
+      "tools"
+    else if type == "plugin" then
+      "plugins"
+    else if type == "skill" then
+      "skills"
+    else if type == "context" then
+      "contexts"
+    else if type == "config" then
+      "config"
+    else if lib.hasSuffix "s" type then
+      type
+    else
+      "${type}s";
+
+  findById =
+    items: id:
+    let
+      matches = builtins.filter (item: (item.id or null) == id || lib.elem id (item.aliases or [ ])) items;
+    in
+    if matches == [ ] then null else builtins.head matches;
+
+  findContextByPathId =
+    id:
+    let
+      pathMd = ".opencode/context/${id}.md";
+      pathAsIs = ".opencode/context/${id}";
+      matches = builtins.filter (item: (item.path or "") == pathMd || (item.path or "") == pathAsIs) contexts;
+    in
+    if matches == [ ] then null else builtins.head matches;
+
+  resolveComponent =
+    spec:
+    let
+      parsed = parseSpec spec;
+    in
+    if parsed == null then
+      null
+    else if parsed.type == "context" && lib.hasInfix "/" parsed.id then
+      findContextByPathId parsed.id
+    else
+      findById (components.${toRegistryKey parsed.type} or [ ]) parsed.id;
+
+  stripMdSuffix = path: if lib.hasSuffix ".md" path then lib.removeSuffix ".md" path else path;
+
+  expandContextPattern =
+    pattern:
+    let
+      match = builtins.match "(.*)\*.*" pattern;
+      prefixRaw = if match == null then pattern else builtins.elemAt match 0;
+      prefix = lib.removeSuffix "/" prefixRaw;
+      prefixWithSlash = if prefix == "" then "" else "${prefix}/";
+      fullPrefix = ".opencode/context/${prefixWithSlash}";
+      matches = builtins.filter (item: lib.hasPrefix fullPrefix (item.path or "")) contexts;
+    in
+    builtins.map (
+      item:
+      "context:${stripMdSuffix (lib.removePrefix ".opencode/context/" item.path)}"
+    ) matches;
+
+  expandSpec =
+    spec:
+    let
+      parsed = parseSpec spec;
+    in
+    if parsed == null then
+      [ ]
+    else if parsed.type == "context" && hasWildcard spec then
+      expandContextPattern parsed.id
+    else
+      [ spec ];
+
+  selectedProfile =
+    if cfg.profile == null then
+      null
+    else if builtins.hasAttr cfg.profile profiles then
+      builtins.getAttr cfg.profile profiles
+    else
+      null;
+
+  profileComponents = if selectedProfile == null then [ ] else selectedProfile.components or [ ];
+  profileAdditionalPaths = if selectedProfile == null then [ ] else selectedProfile.additionalPaths or [ ];
+
+  initialSpecs = lib.unique (lib.concatMap expandSpec (profileComponents ++ cfg.components));
+
+  dependenciesFor =
+    spec:
+    let
+      component = resolveComponent spec;
+      dependencies = if component == null then [ ] else component.dependencies or [ ];
+      expandDependency =
+        dep:
+        let
+          parsed = parseSpec dep;
+        in
+        if parsed != null && parsed.type == "context" && hasWildcard dep then expandContextPattern parsed.id else [ dep ];
+    in
+    lib.unique (lib.concatMap expandDependency dependencies);
+
+  resolveAllDependencies =
+    seen: queue:
+    if queue == [ ] then
+      seen
+    else
+      let
+        current = builtins.head queue;
+        rest = builtins.tail queue;
+      in
+      if lib.elem current seen then
+        resolveAllDependencies seen rest
+      else
+        let
+          deps = dependenciesFor current;
+        in
+        resolveAllDependencies (seen ++ [ current ]) (deps ++ rest);
+
+  resolvedSpecs =
+    if cfg.includeDependencies then
+      resolveAllDependencies [ ] initialSpecs
+    else
+      initialSpecs;
+
+  finalSpecs = builtins.filter (spec: !(lib.elem spec cfg.excludeComponents)) resolvedSpecs;
+
+  sourceFiles =
+    lib.unique (
+      lib.concatMap (
+        spec:
+        let
+          component = resolveComponent spec;
+        in
+        if component == null then [ ] else if component ? files then component.files else [ component.path ]
+      ) finalSpecs
+    );
+
+  layoutMap = {
+    agent = cfg.layout.agent;
+    command = cfg.layout.command;
+    context = cfg.layout.context;
+    tool = cfg.layout.tool;
+    plugin = cfg.layout.plugin;
+    skills = cfg.layout.skills;
+    config = cfg.layout.config;
+  };
+
+  mapRelativePath =
+    sourcePath:
+    if builtins.hasAttr sourcePath cfg.pathOverrides then
+      builtins.getAttr sourcePath cfg.pathOverrides
+    else if lib.hasPrefix ".opencode/" sourcePath then
+      let
+        rel = lib.removePrefix ".opencode/" sourcePath;
+        segments = lib.splitString "/" rel;
+        headSegment = builtins.head segments;
+        tailSegments = builtins.tail segments;
+        mappedHead =
+          if builtins.hasAttr headSegment layoutMap then builtins.getAttr headSegment layoutMap else headSegment;
+        mappedSegments = if mappedHead == "" then tailSegments else [ mappedHead ] ++ tailSegments;
+      in
+      lib.concatStringsSep "/" mappedSegments
+    else if cfg.layout.config == "" then
+      sourcePath
+    else
+      "${cfg.layout.config}/${sourcePath}";
+
+  withTargetRoot =
+    rel:
+    if cfg.targetRoot == "" then
+      rel
+    else
+      "${cfg.targetRoot}/${rel}";
+
+  contextReferencePath =
+    if cfg.contextReferencePath != null then cfg.contextReferencePath else "${config.xdg.configHome}/${withTargetRoot cfg.layout.context}";
+
+  rewriteContextRefs =
+    text:
+    if cfg.rewriteContextReferences then
+      builtins.replaceStrings
+        [
+          "@.opencode/context/"
+          ".opencode/context"
+        ]
+        [
+          "@${contextReferencePath}/"
+          contextReferencePath
+        ]
+        text
+    else
+      text;
+
+  mkGeneratedFileEntry =
+    sourcePath:
+    let
+      src = "${source}/${sourcePath}";
+      destRel = mapRelativePath sourcePath;
+      key = withTargetRoot destRel;
+      fileValue =
+        if cfg.rewriteContextReferences then
+          {
+            text = rewriteContextRefs (builtins.readFile src);
+          }
+        else
+          {
+            source = src;
+          };
+    in
+    nameValuePair key ({ force = cfg.force; } // fileValue);
+
+  generatedFileEntries = builtins.listToAttrs (builtins.map mkGeneratedFileEntry sourceFiles);
+
+  additionalPaths = if cfg.installAdditionalPaths then profileAdditionalPaths else [ ];
+
+  mkAdditionalPathEntry =
+    relPath:
+    let
+      cleanRel = lib.removeSuffix "/" relPath;
+      src = "${source}/${cleanRel}";
+      destRel =
+        if cfg.additionalPathsPrefix == "" then
+          cleanRel
+        else
+          "${cfg.additionalPathsPrefix}/${cleanRel}";
+      key = withTargetRoot destRel;
+      base = {
+        source = src;
+        force = cfg.force;
+      };
+      recursiveAttrs = if lib.pathIsDirectory src then { recursive = true; } else { };
+    in
+    nameValuePair key (base // recursiveAttrs);
+
+  additionalPathEntries = builtins.listToAttrs (builtins.map mkAdditionalPathEntry additionalPaths);
+
+  mkUserEntry =
+    key: value:
+    nameValuePair
+      (withTargetRoot key)
+      (
+        { force = cfg.force; }
+        // (if lib.isPath value then { source = value; } else { text = value; })
+      );
+
+  extraFileEntries = mapAttrs' mkUserEntry cfg.extraFiles;
+  overrideEntries = mapAttrs' mkUserEntry cfg.overrides;
+
+  missingFiles = builtins.filter (path: !(builtins.pathExists "${source}/${path}")) sourceFiles;
+in
+{
+  options.programs.opencode.oac = {
+    enable = mkEnableOption "OpenAgentsControl profile installation for Home Manager OpenCode";
+
+    enableOpencode = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Enable `programs.opencode` automatically when OAC is enabled.";
+    };
+
+    source = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        OAC source tree containing `registry.json` and `.opencode/` files.
+
+        By default this uses the source tree of this flake.
+      '';
+    };
+
+    profile = mkOption {
+      type = types.nullOr (types.enum [
+        "essential"
+        "developer"
+        "business"
+        "full"
+        "advanced"
+      ]);
+      default = "developer";
+      description = ''
+        Profile to install from OAC `registry.json`.
+
+        Set to `null` for custom-only component selection.
+      '';
+    };
+
+    components = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [
+        "agent:openagent"
+        "command:add-context"
+        "context:core/*"
+      ];
+      description = "Extra components to install on top of the selected profile.";
+    };
+
+    excludeComponents = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "plugin:notify" ];
+      description = "Component specs to exclude after profile/dependency expansion.";
+    };
+
+    includeDependencies = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Resolve and include transitive dependencies from `registry.json`.";
+    };
+
+    targetRoot = mkOption {
+      type = types.str;
+      default = "opencode";
+      description = ''
+        Base directory under `$XDG_CONFIG_HOME` where OAC files are installed.
+
+        Example: `opencode` -> `$XDG_CONFIG_HOME/opencode/...`
+      '';
+    };
+
+    layout = {
+      agent = mkOption {
+        type = types.str;
+        default = "agent";
+        description = "Directory name for OAC agent files.";
+      };
+
+      command = mkOption {
+        type = types.str;
+        default = "command";
+        description = "Directory name for OAC command files.";
+      };
+
+      context = mkOption {
+        type = types.str;
+        default = "context";
+        description = "Directory name for OAC context files.";
+      };
+
+      tool = mkOption {
+        type = types.str;
+        default = "tool";
+        description = "Directory name for OAC tools.";
+      };
+
+      plugin = mkOption {
+        type = types.str;
+        default = "plugin";
+        description = "Directory name for OAC plugins.";
+      };
+
+      skills = mkOption {
+        type = types.str;
+        default = "skills";
+        description = "Directory name for OAC skills.";
+      };
+
+      config = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          Directory name for config-root files that are not under `.opencode/` (for example `env.example`).
+
+          Empty string keeps them at the target root.
+        '';
+      };
+    };
+
+    pathOverrides = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      example = {
+        ".opencode/agent/core/openagent.md" = "agents/openagent.md";
+      };
+      description = "Exact source-path to destination-path overrides for generated OAC files.";
+    };
+
+    rewriteContextReferences = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Rewrite `.opencode/context` references in installed file content to a global config path,
+        mirroring the installer's global path rewrite behavior.
+      '';
+    };
+
+    contextReferencePath = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Explicit path used for rewritten context references.
+
+        When null, defaults to `${config.xdg.configHome}/<targetRoot>/<layout.context>`.
+      '';
+    };
+
+    installAdditionalPaths = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Install profile `additionalPaths` entries (currently used by `advanced`) as recursive xdg config files.
+
+        The install script currently reports these as manual downloads.
+      '';
+    };
+
+    additionalPathsPrefix = mkOption {
+      type = types.str;
+      default = "additional";
+      description = "Destination prefix under `targetRoot` for profile `additionalPaths` when enabled.";
+    };
+
+    force = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Set `xdg.configFile.<name>.force` for generated OAC files.";
+    };
+
+    extraFiles = mkOption {
+      type = types.attrsOf (types.either types.lines types.path);
+      default = { };
+      example = {
+        "context/project-intelligence/technical-domain.md" = ./technical-domain.md;
+      };
+      description = "Additional files installed under `targetRoot` after generated profile files.";
+    };
+
+    overrides = mkOption {
+      type = types.attrsOf (types.either types.lines types.path);
+      default = { };
+      example = {
+        "agent/core/openagent.md" = ./openagent.md;
+      };
+      description = "Final override files/text installed under `targetRoot` (applied last).";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = source != null;
+        message = "programs.opencode.oac.source is null and no default oacSource was provided by the flake module.";
+      }
+      {
+        assertion = builtins.pathExists "${source}/registry.json";
+        message = "OAC source does not contain registry.json.";
+      }
+      {
+        assertion = missingFiles == [ ];
+        message =
+          "Some resolved OAC files were not found in source: "
+          + lib.concatStringsSep ", " missingFiles;
+      }
+    ];
+
+    warnings =
+      lib.optional
+        (
+          cfg.profile == "advanced"
+          && profileAdditionalPaths != [ ]
+          && !cfg.installAdditionalPaths
+        )
+        "programs.opencode.oac.profile=advanced includes additionalPaths in registry.json, but installAdditionalPaths=false so they are skipped (matching install.sh behavior).";
+
+    programs.opencode.enable = mkIf cfg.enableOpencode (mkDefault true);
+
+    xdg.configFile = generatedFileEntries // additionalPathEntries // extraFileEntries // overrideEntries;
+  };
+}


### PR DESCRIPTION
## Description
Adds native Nix flake support to the repo, introduces an automated GitHub Action to update flake.lock and commit it only after successful validation/build, and adds a new optional README section explaining Nix installation.

## Type of Change
- [x] New feature (agent, command, tool)
- [ ] Bug fix
- [x] Documentation
- [ ] Refactoring
- [x] CI/CD

## Checklist
- [x] Tests pass locally
- [x] Documentation updated (if needed)
- [x] Follows [CONTRIBUTING.md](docs/contributing/CONTRIBUTING.md)

## Testing
Tested with Github Actions for: Automatic flake.lock updating & test building.