### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/.opencode/prompts/core/openagent/README.md
+++ b/.opencode/prompts/core/openagent/README.md
@@ -193,8 +193,9 @@ open ../results/index.html
 ### `minimax.md` - MiniMax Optimized
 
 **Target Models:**
-- `minimax/MiniMax-M2.7` (latest, 1M context window)
-- `minimax/MiniMax-M2.7-highspeed` (same performance, faster)
+- `minimax/MiniMax-M3` (latest flagship, default — 512K context, 128K max output, image input)
+- `minimax/MiniMax-M2.7` (previous generation, 1M context window)
+- `minimax/MiniMax-M2.7-highspeed` (previous generation, faster)
 
 **Optimizations:**
 - Structured with clear sections and explicit instructions
@@ -214,12 +215,12 @@ open ../results/index.html
 
 **Known Issues:** None documented yet
 
-**Use When:** Using MiniMax models (M2.7 family)
+**Use When:** Using MiniMax models (M3 recommended, M2.7 family for legacy)
 
 **Setup:**
 1. Get your API key from [MiniMax Platform](https://platform.minimax.io)
 2. Set `MINIMAX_API_KEY` in your environment
-3. Configure model: `minimax/MiniMax-M2.7` or `minimax/MiniMax-M2.7-highspeed`
+3. Configure model: `minimax/MiniMax-M3` (recommended), `minimax/MiniMax-M2.7`, or `minimax/MiniMax-M2.7-highspeed`
 
 ---
 

--- a/.opencode/prompts/core/openagent/minimax.md
+++ b/.opencode/prompts/core/openagent/minimax.md
@@ -28,8 +28,9 @@ permissions:
 # Prompt Metadata
 model_family: "minimax"
 recommended_models:
-  - "minimax/MiniMax-M2.7"               # Latest, peak performance (1M context)
-  - "minimax/MiniMax-M2.7-highspeed"     # Same performance, faster and more agile
+  - "minimax/MiniMax-M3"                 # Latest flagship, default (512K context, 128K max output)
+  - "minimax/MiniMax-M2.7"               # Previous generation, peak performance (1M context)
+  - "minimax/MiniMax-M2.7-highspeed"     # Previous generation, faster and more agile
 tested_with: null
 last_tested: null
 maintainer: "community"

--- a/evals/framework/src/sdk/__tests__/minimax-integration.test.ts
+++ b/evals/framework/src/sdk/__tests__/minimax-integration.test.ts
@@ -30,6 +30,12 @@ describe('MiniMax Integration', () => {
   });
 
   describe('model behavior integration', () => {
+    it('should resolve MiniMax-M3 via provider prefix', () => {
+      const behavior = getModelBehavior('minimax/MiniMax-M3');
+      expect(behavior).not.toBe(MODEL_BEHAVIORS['default']);
+      expect(behavior.typicalResponseTime).toBe(8000);
+    });
+
     it('should resolve MiniMax-M2.7 via provider prefix', () => {
       const behavior = getModelBehavior('minimax/MiniMax-M2.7');
       expect(behavior).not.toBe(MODEL_BEHAVIORS['default']);
@@ -43,10 +49,13 @@ describe('MiniMax Integration', () => {
     });
 
     it('should calculate appropriate timeouts for eval tests', () => {
+      const m3Timeout = calculateModelTimeout(30000, 'minimax/MiniMax-M3');
       const standardTimeout = calculateModelTimeout(30000, 'minimax/MiniMax-M2.7');
       const highspeedTimeout = calculateModelTimeout(30000, 'minimax/MiniMax-M2.7-highspeed');
 
-      // Both should be reasonable for eval tests
+      // All should be reasonable for eval tests
+      expect(m3Timeout).toBeGreaterThanOrEqual(24000);
+      expect(m3Timeout).toBeLessThanOrEqual(120000);
       expect(standardTimeout).toBeGreaterThanOrEqual(24000);
       expect(standardTimeout).toBeLessThanOrEqual(120000);
       expect(highspeedTimeout).toBeGreaterThanOrEqual(15000);

--- a/evals/framework/src/sdk/__tests__/minimax-model-behaviors.test.ts
+++ b/evals/framework/src/sdk/__tests__/minimax-model-behaviors.test.ts
@@ -10,12 +10,24 @@ import { MODEL_BEHAVIORS, getModelBehavior, calculateModelTimeout } from '../mod
 
 describe('MiniMax Model Behaviors', () => {
   describe('MODEL_BEHAVIORS registry', () => {
+    it('should include MiniMax-M3 entry', () => {
+      expect(MODEL_BEHAVIORS['MiniMax-M3']).toBeDefined();
+    });
+
     it('should include MiniMax-M2.7 entry', () => {
       expect(MODEL_BEHAVIORS['MiniMax-M2.7']).toBeDefined();
     });
 
     it('should include MiniMax-M2.7-highspeed entry', () => {
       expect(MODEL_BEHAVIORS['MiniMax-M2.7-highspeed']).toBeDefined();
+    });
+
+    it('should have correct properties for MiniMax-M3', () => {
+      const behavior = MODEL_BEHAVIORS['MiniMax-M3'];
+      expect(behavior.sendsCompletionText).toBe(true);
+      expect(behavior.mayEndWithToolCalls).toBe(false);
+      expect(behavior.typicalResponseTime).toBe(8000);
+      expect(behavior.toolCompletionGrace).toBe(4000);
     });
 
     it('should have correct properties for MiniMax-M2.7', () => {
@@ -42,6 +54,11 @@ describe('MiniMax Model Behaviors', () => {
   });
 
   describe('getModelBehavior()', () => {
+    it('should return exact match for MiniMax-M3', () => {
+      const behavior = getModelBehavior('MiniMax-M3');
+      expect(behavior).toBe(MODEL_BEHAVIORS['MiniMax-M3']);
+    });
+
     it('should return exact match for MiniMax-M2.7', () => {
       const behavior = getModelBehavior('MiniMax-M2.7');
       expect(behavior).toBe(MODEL_BEHAVIORS['MiniMax-M2.7']);
@@ -50,6 +67,11 @@ describe('MiniMax Model Behaviors', () => {
     it('should return exact match for MiniMax-M2.7-highspeed', () => {
       const behavior = getModelBehavior('MiniMax-M2.7-highspeed');
       expect(behavior).toBe(MODEL_BEHAVIORS['MiniMax-M2.7-highspeed']);
+    });
+
+    it('should return partial match for minimax/MiniMax-M3', () => {
+      const behavior = getModelBehavior('minimax/MiniMax-M3');
+      expect(behavior.typicalResponseTime).toBe(8000);
     });
 
     it('should return partial match for minimax/MiniMax-M2.7', () => {
@@ -64,6 +86,11 @@ describe('MiniMax Model Behaviors', () => {
   });
 
   describe('calculateModelTimeout()', () => {
+    it('should calculate timeout for MiniMax-M3', () => {
+      const timeout = calculateModelTimeout(30000, 'MiniMax-M3');
+      expect(timeout).toBeGreaterThanOrEqual(24000); // At least 3x typicalResponseTime
+    });
+
     it('should calculate timeout for MiniMax-M2.7', () => {
       const timeout = calculateModelTimeout(30000, 'MiniMax-M2.7');
       expect(timeout).toBeGreaterThanOrEqual(24000); // At least 3x typicalResponseTime

--- a/evals/framework/src/sdk/__tests__/minimax-prompt-variant.test.ts
+++ b/evals/framework/src/sdk/__tests__/minimax-prompt-variant.test.ts
@@ -29,11 +29,15 @@ describe('MiniMax Prompt Variant', () => {
       expect(content).toContain('model_family: "minimax"');
     });
 
-    it('should recommend MiniMax-M2.7 as primary model', () => {
+    it('should recommend MiniMax-M3 as primary model', () => {
+      expect(content).toContain('minimax/MiniMax-M3');
+    });
+
+    it('should retain MiniMax-M2.7 as legacy alternative', () => {
       expect(content).toContain('minimax/MiniMax-M2.7');
     });
 
-    it('should recommend MiniMax-M2.7-highspeed as alternative', () => {
+    it('should retain MiniMax-M2.7-highspeed as legacy alternative', () => {
       expect(content).toContain('minimax/MiniMax-M2.7-highspeed');
     });
 

--- a/evals/framework/src/sdk/model-behaviors.ts
+++ b/evals/framework/src/sdk/model-behaviors.ts
@@ -73,6 +73,12 @@ export const MODEL_BEHAVIORS: Record<string, ModelBehavior> = {
     typicalResponseTime: 6000,
     toolCompletionGrace: 3000,
   },
+  'MiniMax-M3': {
+    sendsCompletionText: true,
+    mayEndWithToolCalls: false,
+    typicalResponseTime: 8000,
+    toolCompletionGrace: 4000,
+  },
   'MiniMax-M2.7-highspeed': {
     sendsCompletionText: true,
     mayEndWithToolCalls: false,


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to include the latest M3 model as the default recommended model.

## Changes
- Add `MiniMax-M3` to `MODEL_BEHAVIORS` registry in `evals/framework/src/sdk/model-behaviors.ts`
- Promote `minimax/MiniMax-M3` as the primary recommended model in the `minimax` prompt variant
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as legacy alternatives
- Update prompt variants README with M3 as the new flagship target model
- Extend unit and integration tests to cover M3 alongside the M2.7 family

## Why
MiniMax-M3 is the new flagship model with a 512K context window, 128K max output, and image input support across both OpenAI-compatible and Anthropic-compatible interfaces. Adding it as the default keeps the existing M2.7 entries available for users who still prefer the previous generation.

## Testing
- minimax-related unit tests updated and passing locally (42/42 tests pass across `minimax-model-behaviors.test.ts`, `minimax-prompt-variant.test.ts`, and `minimax-integration.test.ts`)
- No changes to API base URL, env variables, or TTS configuration