### PR TITLE
[verified] fix: register missing TypeScript and C# context docs for issue #322

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1650,6 +1650,46 @@
         "category": "standard"
       },
       {
+        "id": "typescript",
+        "name": "TypeScript",
+        "type": "context",
+        "path": ".opencode/context/core/standards/typescript.md",
+        "description": "Universal TypeScript language and engineering standards",
+        "tags": [
+          "typescript",
+          "standards"
+        ],
+        "dependencies": [],
+        "category": "standard"
+      },
+      {
+        "id": "csharp",
+        "name": "C#",
+        "type": "context",
+        "path": ".opencode/context/core/standards/csharp.md",
+        "description": "Universal C# standards",
+        "tags": [
+          "csharp",
+          "standards"
+        ],
+        "dependencies": [],
+        "category": "standard"
+      },
+      {
+        "id": "csharp-project-structure",
+        "name": "C# Project Structure",
+        "type": "context",
+        "path": ".opencode/context/core/standards/csharp-project-structure.md",
+        "description": "ASP.NET Core project structure and implementation patterns",
+        "tags": [
+          "csharp",
+          "standards",
+          "project-structure"
+        ],
+        "dependencies": [],
+        "category": "standard"
+      },
+      {
         "id": "documentation",
         "name": "Documentation",
         "type": "context",

--- a/scripts/registry/validate-registry.sh
+++ b/scripts/registry/validate-registry.sh
@@ -163,6 +163,7 @@ validate_component_paths() {
             fi
         fi
     done <<< "$components"
+    return 0
 }
 
 suggest_fix() {
@@ -287,6 +288,9 @@ check_dependency_exists() {
         plugin)
             registry_category="plugins"
             ;;
+        skill)
+            registry_category="skills"
+            ;;
         context)
             registry_category="contexts"
             ;;
@@ -380,7 +384,7 @@ validate_component_dependencies() {
                 fi
                 
                 local result
-                result=$(check_dependency_exists "$dep")
+                result=$(check_dependency_exists "$dep" || true)
                 
                 case "$result" in
                     found)


### PR DESCRIPTION
## Summary
- Registers three missing built-in context entries in `registry.json`: TypeScript, C# language, and C# Project Structure.
- Fixes registry dependency validation to recognize `skill:` targets by mapping them to `skills`.
- Adds a guarded dependency lookup in `scripts/registry/validate-registry.sh` to avoid `set -e` exits when dependency resolution fails in command substitution.

## Checks
- `python3 -m json.tool registry.json`
- `bash -n scripts/registry/validate-registry.sh`
- `./scripts/registry/validate-registry.sh --verbose`
- `npm run -s validate:registry:verbose`

## Verification
- Independent reviewer prompt (delegate_task) passed with no security or logic blockers.

Closes #322
