### PR TITLE
fix(update): skip unmanaged local files silently, consolidate find loops

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -54,16 +54,13 @@ REPO_URL="https://raw.githubusercontent.com/darrenhinde/OpenAgentsControl/${BRAN
 # CLI argument for custom install dir (overrides env var)
 CUSTOM_INSTALL_DIR=""
 
-# Track backup files for cleanup on exit
-BACKUP_FILES=()
+# Temp file for downloads — shared across update_component calls
+TMP_FILE=""
 
-# Clean up any leftover backup files on exit/interrupt
-cleanup_backups() {
-    for f in "${BACKUP_FILES[@]}"; do
-        [ -f "$f" ] && rm -f "$f"
-    done
+cleanup_tmp() {
+    [ -n "$TMP_FILE" ] && [ -f "$TMP_FILE" ] && rm -f "$TMP_FILE"
 }
-trap cleanup_backups EXIT INT TERM
+trap cleanup_tmp EXIT INT TERM
 
 #############################################################################
 # Utility Functions
@@ -79,7 +76,7 @@ print_header() {
     echo -e "${CYAN}${BOLD}"
     echo "╔════════════════════════════════════════════════════════════════╗"
     echo "║                                                                ║"
-    echo "║           OpenAgents Control Updater v1.1.0                   ║"
+    echo "║           OpenAgents Control Updater v1.2.0                   ║"
     echo "║                                                                ║"
     echo "╚════════════════════════════════════════════════════════════════╝"
     echo -e "${NC}"
@@ -197,6 +194,8 @@ resolve_install_dir() {
 # Update Logic
 #############################################################################
 
+COUNT_LOCAL_ONLY=0
+
 update_component() {
     local path="$1"
     local install_dir="$2"
@@ -209,23 +208,17 @@ update_component() {
     fi
 
     local url="${REPO_URL}/.opencode/${relative_path}"
-    local backup="${path}.backup"
 
-    cp "$path" "$backup"
-    BACKUP_FILES+=("$backup")
+    # Download to temp — silently skip files not present in the remote
+    if ! curl -fsSL "$url" -o "$TMP_FILE" 2>/dev/null; then
+        COUNT_LOCAL_ONLY=$((COUNT_LOCAL_ONLY + 1))
+        return 0
+    fi
 
-    if curl -fsSL "$url" -o "$path" 2>/dev/null; then
-        print_success "Updated $path"
-        rm -f "$backup"
-        # Remove from tracking array (bash 3.2 compatible)
-        local new_backups=()
-        for f in "${BACKUP_FILES[@]}"; do
-            [ "$f" != "$backup" ] && new_backups+=("$f")
-        done
-        BACKUP_FILES=("${new_backups[@]+"${new_backups[@]}"}")
+    if cp "$TMP_FILE" "$path"; then
+        print_success "Updated ${relative_path}"
     else
-        print_warning "Could not update $path — restoring backup"
-        mv "$backup" "$path"
+        print_warning "Could not write ${relative_path}"
         return 1
     fi
 }
@@ -234,6 +227,8 @@ update_all_components() {
     local install_dir="$1"
     local updated=0
     local failed=0
+
+    TMP_FILE="$(mktemp)"
 
     # Update markdown files
     while IFS= read -r -d '' file; do
@@ -262,7 +257,7 @@ update_all_components() {
         fi
     done < <(find "$install_dir" -name "*.sh" -type f -print0)
 
-    print_info "Updated: $updated file(s), failed: $failed file(s)"
+    print_info "Updated: $updated | Skipped (local-only): $COUNT_LOCAL_ONLY | Failed: $failed"
 }
 
 #############################################################################

--- a/update.sh
+++ b/update.sh
@@ -230,32 +230,16 @@ update_all_components() {
 
     TMP_FILE="$(mktemp)"
 
-    # Update markdown files
     while IFS= read -r -d '' file; do
         if update_component "$file" "$install_dir"; then
             updated=$((updated + 1))
         else
             failed=$((failed + 1))
         fi
-    done < <(find "$install_dir" -name "*.md" -type f -print0)
-
-    # Update TypeScript files
-    while IFS= read -r -d '' file; do
-        if update_component "$file" "$install_dir"; then
-            updated=$((updated + 1))
-        else
-            failed=$((failed + 1))
-        fi
-    done < <(find "$install_dir" -name "*.ts" -type f -not -path "*/node_modules/*" -print0)
-
-    # Update shell scripts inside install dir
-    while IFS= read -r -d '' file; do
-        if update_component "$file" "$install_dir"; then
-            updated=$((updated + 1))
-        else
-            failed=$((failed + 1))
-        fi
-    done < <(find "$install_dir" -name "*.sh" -type f -print0)
+    done < <(find "$install_dir" \
+        -type f \( -name "*.md" -o -name "*.ts" -o -name "*.sh" \) \
+        -not -path "*/node_modules/*" \
+        -print0)
 
     print_info "Updated: $updated | Skipped (local-only): $COUNT_LOCAL_ONLY | Failed: $failed"
 }


### PR DESCRIPTION
## Description
Previously, any file present locally but absent from the remote repo produced a `Could not update` warning — identical in appearance to a genuine failure. In practice this affects every installation: users commonly have local-only files (custom commands, skills, config) sitting alongside OAC-managed files in the same directory.

Two changes:
1. **Silent skip for unmanaged files** — a 404 response is no longer treated as a failure. Local-only files are counted and shown in the summary line only.
2. **Consolidated `find`** — three sequential find/loop blocks (md, ts, sh) replaced with a single pass.

Also replaces the per-file backup/restore mechanism with a single shared temp file. Downloading to temp before overwriting the destination achieves the same safety guarantee (no partial overwrites) with less code.

Summary line before:
```
Updated: 3 file(s), failed: 47 file(s)
```
Summary line after:
```
Updated: 3 | Skipped (local-only): 47 | Failed: 0
```

## Type of Change
- [ ] New feature (agent, command, tool)
- [x] Bug fix
- [ ] Documentation
- [x] Refactoring
- [ ] CI/CD

## Checklist
- [x] Tests pass locally
- [ ] Documentation updated (if needed)
- [x] Follows [CONTRIBUTING.md](docs/contributing/CONTRIBUTING.md)

## Testing
Ran `update.sh --install-dir ~/.config/opencode` against a global install directory containing ~130 OAC-managed files and ~16 local-only files. Local-only files were silently skipped and counted; OAC-managed files were updated as expected. No backup files left behind.