### PR TITLE
fix(ClaudeAdapter): strip surrounding quotes from scalar frontmatter values

### DIFF
--- a/packages/compatibility-layer/src/adapters/ClaudeAdapter.ts
+++ b/packages/compatibility-layer/src/adapters/ClaudeAdapter.ts
@@ -276,6 +276,11 @@ export class ClaudeAdapter extends BaseAdapter {
             .slice(1, -1)
             .split(",")
             .map((v) => v.trim().replace(/"/g, ""));
+        } else if (typeof value === "string") {
+          // Strip surrounding quotes from scalar values (matches
+          // CursorAdapter.parseFrontmatter, and undoes the quoting that
+          // generateClaudeAgentMarkdown adds, e.g. name: "...").
+          value = value.replace(/^["']|["']$/g, "");
         }
 
         frontmatter[key] = value;

--- a/packages/compatibility-layer/tests/unit/adapters/ClaudeAdapter.test.ts
+++ b/packages/compatibility-layer/tests/unit/adapters/ClaudeAdapter.test.ts
@@ -235,6 +235,24 @@ This is the system prompt for the agent.`;
       expect(result.systemPrompt).toBe("This is the system prompt for the agent.");
     });
 
+    it("strips surrounding quotes from scalar frontmatter values", async () => {
+      // generateClaudeAgentMarkdown emits quoted scalars (name: "..."), so a
+      // fromOAC -> toOAC round-trip must not leave the embedded quotes.
+      const source = `---
+name: "SubAgent"
+description: "A subagent"
+model: "claude-opus-4"
+---
+
+Prompt body`;
+
+      const result = await adapter.toOAC(source);
+
+      expect(result.frontmatter.name).toBe("SubAgent");
+      expect(result.frontmatter.description).toBe("A subagent");
+      expect(result.frontmatter.model).toBe("claude-opus-4");
+    });
+
     it("parses agent.md with model in frontmatter", async () => {
       const source = `---
 name: Agent


### PR DESCRIPTION
## Problem

`ClaudeAdapter.parseFrontmatter` (`packages/compatibility-layer/src/adapters/ClaudeAdapter.ts`) is a small hand-rolled YAML parser. It strips quotes only from **array** items, never from **scalar** values:

```ts
let value: unknown = line.slice(colonIndex + 1).trim();
if (typeof value === "string" && value.startsWith("[") && value.endsWith("]")) {
  value = value.slice(1, -1).split(",").map((v) => v.trim().replace(/"/g, ""));
}
frontmatter[key] = value;   // scalar quotes never stripped
```

So a quoted scalar like `name: "SubAgent"` parses to the literal string `"SubAgent"` (embedded quotes). This is not hypothetical: the adapter's **own** generator `generateClaudeAgentMarkdown` emits every scalar quoted (`name: "..."`, `description: "..."`, `model: "..."`), so a subagent `fromOAC → toOAC` round-trip corrupts those fields. The sibling `CursorAdapter.parseFrontmatter` already does `value.replace(/^["']|["']$/g, "")`, which proves the intended behavior.

## Reproduction

Frontmatter as produced by `fromOAC` for a subagent:

```
name: "SubAgent"
description: "A subagent"
```

- **Before:** `frontmatter.name === '"SubAgent"'` (embedded quotes) ❌
- **After:** `frontmatter.name === 'SubAgent'` ✅

## Fix

Strip surrounding quotes from scalar values, mirroring `CursorAdapter`:

```ts
} else if (typeof value === "string") {
  value = value.replace(/^["']|["']$/g, "");
}
```

## Test

Added `strips surrounding quotes from scalar frontmatter values` to `ClaudeAdapter.test.ts` (the existing suite only exercised the primary/JSON path, not a quoted-scalar subagent parse). It fails on the current code and passes after the fix; full `ClaudeAdapter.test.ts`: **81 passed** (`vitest run`).
