### PR TITLE
feat(compatibility-layer): add OpenClaw adapter with non-degrading permission mapping

### DIFF
--- a/packages/compatibility-layer/README.md
+++ b/packages/compatibility-layer/README.md
@@ -15,6 +15,7 @@ This package provides bidirectional conversion between OpenAgents Control (OAC) 
 - **Claude Code** - Anthropic's official CLI with `config.json` and `agents/*.md`
   [![Claude Code](./docs/migration-guides/claude-code-validation.png)](./docs/migration-guides/oac-to-claude.md)
 - **Windsurf** - AI-powered development environment with JSON config
+- **OpenClaw** - open gateway platform with granular permission support (no degradation)
 
 ## Features
 
@@ -25,6 +26,7 @@ This package provides bidirectional conversion between OpenAgents Control (OAC) 
 - ✅ **Batch migration** - Migrate entire projects at once
 - ✅ **Type-safe** - Full TypeScript with Zod validation
 - ✅ **Extensible** - Plugin architecture for new tools
+- ✅ **OpenClaw adapter** - Full granular permission mapping preserved (allow/deny/ask, no binary degradation)
 
 ## Installation
 

--- a/packages/compatibility-layer/src/adapters/OpenClawAdapter.ts
+++ b/packages/compatibility-layer/src/adapters/OpenClawAdapter.ts
@@ -1,0 +1,248 @@
+import { BaseAdapter } from "./BaseAdapter.js";
+import type {
+  OpenAgent,
+  ConversionResult,
+  ToolCapabilities,
+  ToolConfig,
+} from "../types.js";
+import { createPermissionIndex } from "../mappers/PermissionMapper.js";
+
+/**
+ * OpenClaw adapter for converting between OpenAgents Control and OpenClaw formats.
+ *
+ * OpenClaw is the Gateway agent platform. Unlike Claude/Cursor/Windsurf,
+ * OpenClaw supports FULL granular permissions via the before_tool_call hook,
+ * so this adapter performs NO permission degradation.
+ *
+ * Conversion outputs (fromOAC, one config fragment per agent):
+ * - `.openclaw/agents/{agentId}.json`        — agents.list entry (primary) or subagent config (subagent)
+ * - `.openclaw/bootstrap-manifest.json`      — primary agent body (6-stage workflow guidance) for agent:bootstrap injection
+ * - `.openclaw/skills-index.json`            — skills reference list (SKILL.md compatible)
+ * - `.openclaw/permission-index-{agentId}.json` — per-agent granular permission fragment (no degradation).
+ *     The install pipeline aggregates these fragments into the single merged
+ *     `.openclaw/permission-index.json` consumed by the plugin loader.
+ *
+ * @see https://github.com/darrenhinde/OpenAgentsControl
+ */
+export class OpenClawAdapter extends BaseAdapter {
+  readonly name = "openclaw";
+  readonly displayName = "OpenClaw";
+
+  constructor() {
+    super();
+  }
+
+  // ============================================================================
+  // CONVERSION METHODS
+  // ============================================================================
+
+  /**
+   * Convert OpenClaw format TO OpenAgents Control format.
+   *
+   * Phase 1 is fromOAC only (OAC → OpenClaw). Reverse conversion is planned
+   * for Phase 2.
+   *
+   * @throws {Error} Always — not implemented in phase 1
+   */
+  toOAC(_source: string): Promise<OpenAgent> {
+    return Promise.reject(
+      new Error("toOAC not implemented in phase 1 (fromOAC only)")
+    );
+  }
+
+  /**
+   * Convert FROM OpenAgents Control format to OpenClaw format.
+   *
+   * Generates per-agent config fragments (see class docs). No permission
+   * degradation — the full granular table is preserved for hook enforcement.
+   *
+   * @param agent - OpenAgent to convert
+   * @returns ConversionResult with generated files and warnings
+   */
+  fromOAC(agent: OpenAgent): Promise<ConversionResult> {
+    const warnings: string[] = [];
+    const configs: ToolConfig[] = [];
+
+    // Validate conversion
+    warnings.push(...this.validateConversion(agent));
+
+    // Build the OpenClaw agent config object
+    const agentConfig = this.buildOpenClawAgentConfig(agent);
+
+    // Output per-agent config fragment (agents.list entry / subagent config)
+    const agentId = agent.metadata.id || this.slugify(agent.frontmatter.name);
+    configs.push({
+      fileName: `.openclaw/agents/${agentId}.json`,
+      content: JSON.stringify(agentConfig, null, 2),
+      encoding: "utf-8",
+    });
+
+    // Channel 2: bootstrap manifest (primary agent body → agent:bootstrap injection)
+    const isPrimary = agent.frontmatter.mode !== "subagent";
+    if (isPrimary && agent.systemPrompt && agent.systemPrompt.trim().length > 0) {
+      configs.push({
+        fileName: ".openclaw/bootstrap-manifest.json",
+        content: JSON.stringify(
+          {
+            agentId,
+            source: agent.frontmatter.name,
+            guidance: agent.systemPrompt,
+            note: "Injected via agent:bootstrap hook (OAC 6-stage workflow guidance)",
+          },
+          null,
+          2
+        ),
+        encoding: "utf-8",
+      });
+    }
+
+    // Channel 3: skills index (SKILL.md compatible — direct reference, no copy)
+    if (agent.frontmatter.skills && agent.frontmatter.skills.length > 0) {
+      configs.push({
+        fileName: ".openclaw/skills-index.json",
+        content: JSON.stringify(
+          {
+            agentId,
+            skills: agent.frontmatter.skills.map((skill) =>
+              typeof skill === "string" ? skill : skill.name
+            ),
+          },
+          null,
+          2
+        ),
+        encoding: "utf-8",
+      });
+    }
+
+    // Permission fragment — one file per agent so multiple agents with
+    // permission tables never overwrite each other. This is a per-agent
+    // fragment (v1 PermissionIndex shape); the install pipeline merges all
+    // fragments into the single `.openclaw/permission-index.json` that the
+    // plugin's permission-loader consumes.
+    if (agent.frontmatter.permission) {
+      const index = createPermissionIndex(agentId, agent.frontmatter.permission);
+      configs.push({
+        fileName: `.openclaw/permission-index-${agentId}.json`,
+        content: JSON.stringify(index, null, 2),
+        encoding: "utf-8",
+      });
+    }
+
+    return Promise.resolve(this.createSuccessResult(configs, warnings));
+  }
+
+  /**
+   * Get the configuration path for OpenClaw artifacts.
+   */
+  getConfigPath(): string {
+    return ".openclaw/";
+  }
+
+  /**
+   * Get OpenClaw capabilities.
+   */
+  getCapabilities(): ToolCapabilities {
+    return {
+      name: this.name,
+      displayName: this.displayName,
+      supportsMultipleAgents: true,
+      supportsSkills: true,
+      supportsHooks: true,
+      supportsGranularPermissions: true, // ★ Only adapter with full granular support
+      supportsContexts: true,
+      supportsCustomModels: true,
+      supportsTemperature: true,
+      supportsMaxSteps: false, // Not mapped in phase 1
+      configFormat: "json",
+      outputStructure: "directory",
+      notes: [
+        "Granular permissions fully supported via before_tool_call hook (no degradation)",
+        "temperature maps to agents.list[].params.temperature",
+        "Contexts injected via agent:bootstrap hook",
+        "Skills are SKILL.md compatible (AgentSkills spec)",
+        "toOAC (reverse) deferred to phase 2",
+      ],
+    };
+  }
+
+  /**
+   * Validate if an agent can be converted with full fidelity.
+   */
+  validateConversion(agent: OpenAgent): string[] {
+    const warnings: string[] = [];
+
+    if (!agent.frontmatter.name) {
+      warnings.push("⚠️  Agent name is required for OpenClaw");
+    }
+
+    if (!agent.frontmatter.description) {
+      warnings.push("⚠️  Agent description is required for OpenClaw");
+    }
+
+    if (agent.frontmatter.maxSteps !== undefined) {
+      warnings.push(
+        this.unsupportedFeatureWarning("maxSteps", agent.frontmatter.maxSteps)
+      );
+    }
+
+    // No granular permission warnings — OpenClaw supports full granular permissions.
+    return warnings;
+  }
+
+  // ============================================================================
+  // GENERATION HELPERS (fromOAC)
+  // ============================================================================
+
+  /**
+   * Build the OpenClaw agent config object.
+   */
+  private buildOpenClawAgentConfig(
+    agent: OpenAgent
+  ): Record<string, unknown> {
+    // NOTE: mode routing (agents.list vs subagents) is NOT expressed via an
+    // `entryType` field — OpenClaw's config schema rejects unknown fields
+    // (additionalProperties: false). Routing is expressed by fileName in
+    // fromOAC() (`frontmatter.mode !== "subagent"` decides whether the
+    // bootstrap-manifest channel is emitted) plus the OpenClaw-side
+    // agents.list/subagents structure.
+
+    const config: Record<string, unknown> = {
+      id: agent.metadata.id || this.slugify(agent.frontmatter.name),
+      name: agent.frontmatter.name,
+    };
+
+    // Model mapping (provider/model reference — preserved as-is by default)
+    if (agent.frontmatter.model) {
+      config.model = agent.frontmatter.model;
+    }
+
+    // Temperature → params.temperature
+    if (agent.frontmatter.temperature !== undefined) {
+      config.params = { temperature: agent.frontmatter.temperature };
+    }
+
+    // Skills → agents.list[].skills
+    if (agent.frontmatter.skills && agent.frontmatter.skills.length > 0) {
+      config.skills = agent.frontmatter.skills.map((skill) =>
+        typeof skill === "string" ? skill : skill.name
+      );
+    }
+
+    // description → bootstrap note (OpenClaw has no agents.list[].description)
+    if (agent.frontmatter.description) {
+      config.description = agent.frontmatter.description;
+    }
+
+    return config;
+  }
+
+  /**
+   * Slugify a name into a kebab-case identifier.
+   */
+  private slugify(name: string): string {
+    return name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+  }
+}

--- a/packages/compatibility-layer/src/adapters/OpenClawAdapter.ts
+++ b/packages/compatibility-layer/src/adapters/OpenClawAdapter.ts
@@ -16,7 +16,10 @@ import { createPermissionIndex } from "../mappers/PermissionMapper.js";
  *
  * Conversion outputs (fromOAC, one config fragment per agent):
  * - `.openclaw/agents/{agentId}.json`        — agents.list entry (primary) or subagent config (subagent)
- * - `.openclaw/bootstrap-manifest.json`      — primary agent body (6-stage workflow guidance) for agent:bootstrap injection
+ * - `.openclaw/bootstrap-manifest-{agentId}.json` — primary agent body (6-stage workflow guidance) for agent:bootstrap injection.
+ *     Per-agent file names prevent same-directory primaries from overwriting
+ *     each other (the plugin routes by agentId and falls back to the legacy
+ *     single `.openclaw/bootstrap-manifest.json`).
  * - `.openclaw/skills-index.json`            — skills reference list (SKILL.md compatible)
  * - `.openclaw/permission-index-{agentId}.json` — per-agent granular permission fragment (no degradation).
  *     The install pipeline aggregates these fragments into the single merged
@@ -78,10 +81,12 @@ export class OpenClawAdapter extends BaseAdapter {
     });
 
     // Channel 2: bootstrap manifest (primary agent body → agent:bootstrap injection)
+    // Per-agent file name (same pattern as permission-index-{agentId}.json) so
+    // multiple primaries under the same directory never overwrite each other.
     const isPrimary = agent.frontmatter.mode !== "subagent";
     if (isPrimary && agent.systemPrompt && agent.systemPrompt.trim().length > 0) {
       configs.push({
-        fileName: ".openclaw/bootstrap-manifest.json",
+        fileName: `.openclaw/bootstrap-manifest-${agentId}.json`,
         content: JSON.stringify(
           {
             agentId,

--- a/packages/compatibility-layer/src/cli/__tests__/migrate.test.ts
+++ b/packages/compatibility-layer/src/cli/__tests__/migrate.test.ts
@@ -475,6 +475,30 @@ You are a second agent for testing.
       expect(result.success).toBe(true);
     });
 
+    it("skips OAC category index files (0-category.json)", async () => {
+      // Arrange
+      const sourceDir = join(TEMP_DIR, "source-discover-category-index");
+      await mkdir(sourceDir, { recursive: true });
+
+      // Category index metadata is NOT an agent file — must be skipped
+      await writeFile(
+        join(sourceDir, "0-category.json"),
+        JSON.stringify({ name: "Core Agents", agents: {} })
+      );
+
+      // Act
+      const result = await executeMigrate(
+        sourceDir,
+        { format: "openclaw", dryRun: true },
+        defaultGlobalOptions
+      );
+
+      // Assert
+      expect(result.success).toBe(true);
+      // No agent files were found → 0 total discovered, no failure from the index
+      expect(result.data?.total).toBe(0);
+    });
+
     it("discovers .cursorrules files", async () => {
       // Arrange
       const sourceDir = join(TEMP_DIR, "source-discover-cursor");
@@ -597,6 +621,130 @@ Content`);
 
       // Assert
       expect(result.success).toBe(true);
+    });
+  });
+
+  // ============================================================================
+  // MULTI-CONFIG ADAPTERS (e.g. OpenClaw)
+  // ============================================================================
+
+  describe("multi-config adapters", () => {
+    // OAC source exercising all OpenClaw output channels:
+    // configs[0] = .openclaw/agents/{id}.json, plus bootstrap-manifest,
+    // skills-index and permission-index additional files.
+    const MULTI_CONFIG_AGENT = `---
+name: "Multi Config Agent"
+description: "Agent that exercises multi-config output"
+mode: primary
+model: claude-sonnet-4
+skills:
+  - web-search
+  - code-review
+permission:
+  bash: allow
+  read: allow
+  write: deny
+---
+
+# Multi Config Agent
+
+You are an agent that exercises the multi-config output path.
+`;
+
+    // Create a source dir with a single multi-config OAC agent,
+    // either nested under subdirectories or at the top level.
+    const createMultiConfigSourceDir = async (
+      dirName: string,
+      nested: boolean
+    ): Promise<string> => {
+      const sourceDir = join(TEMP_DIR, dirName);
+      const agentPath = nested
+        ? join(sourceDir, "subagents", "code", "multi-config.md")
+        : join(sourceDir, "multi-config.md");
+      await mkdir(dirname(agentPath), { recursive: true });
+      await writeFile(agentPath, MULTI_CONFIG_AGENT);
+      return sourceDir;
+    };
+
+    it("writes additional config files into targetDir without nesting", async () => {
+      // Arrange
+      const sourceDir = await createMultiConfigSourceDir("source-multi-nested", true);
+      const outDir = join(TEMP_DIR, "output-multi-nested");
+
+      // Act
+      const result = await executeMigrate(
+        sourceDir,
+        { format: "openclaw", outDir },
+        defaultGlobalOptions
+      );
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.successful).toBeGreaterThan(0);
+
+      // Primary config + additional files all under the source's targetDir
+      const primaryPath = join(
+        outDir, "subagents", "code", ".openclaw", "agents", "multi-config.json"
+      );
+      const bootstrapPath = join(
+        outDir, "subagents", "code", ".openclaw", "bootstrap-manifest.json"
+      );
+      const skillsPath = join(
+        outDir, "subagents", "code", ".openclaw", "skills-index.json"
+      );
+      const permissionPath = join(
+        outDir, "subagents", "code", ".openclaw", "permission-index-multi-config.json"
+      );
+
+      await expect(readFile(primaryPath, "utf-8")).resolves.toContain('"id": "multi-config"');
+      await expect(readFile(bootstrapPath, "utf-8")).resolves.toContain('"agentId": "multi-config"');
+      await expect(readFile(skillsPath, "utf-8")).resolves.toContain('"web-search"');
+      await expect(readFile(permissionPath, "utf-8")).resolves.toContain('"bash"');
+
+      // Additional files are NOT nested under the primary config's subdirectory
+      const nestedPath = join(
+        outDir, "subagents", "code", ".openclaw", "agents", ".openclaw", "permission-index-multi-config.json"
+      );
+      await expect(readFile(nestedPath, "utf-8")).rejects.toMatchObject({ code: "ENOENT" });
+
+      // Content sanity: permission index preserves granular actions
+      const permissionIndex = JSON.parse(await readFile(permissionPath, "utf-8"));
+      expect(permissionIndex.agentId).toBe("multi-config");
+      expect(permissionIndex.tools.bash).toEqual([{ pattern: "*", action: "allow" }]);
+      expect(permissionIndex.tools.write).toEqual([{ pattern: "*", action: "deny" }]);
+
+      // Content sanity: skills index references the declared skills
+      const skillsIndex = JSON.parse(await readFile(skillsPath, "utf-8"));
+      expect(skillsIndex.agentId).toBe("multi-config");
+      expect(skillsIndex.skills).toContain("web-search");
+    });
+
+    it("writes additional config files at output root for top-level sources", async () => {
+      // Arrange
+      const sourceDir = await createMultiConfigSourceDir("source-multi-root", false);
+      const outDir = join(TEMP_DIR, "output-multi-root");
+
+      // Act
+      const result = await executeMigrate(
+        sourceDir,
+        { format: "openclaw", outDir },
+        defaultGlobalOptions
+      );
+
+      // Assert
+      expect(result.success).toBe(true);
+
+      const primaryPath = join(outDir, ".openclaw", "agents", "multi-config.json");
+      const permissionPath = join(outDir, ".openclaw", "permission-index-multi-config.json");
+
+      await expect(readFile(primaryPath, "utf-8")).resolves.toContain('"id": "multi-config"');
+      await expect(readFile(permissionPath, "utf-8")).resolves.toContain('"bash"');
+
+      // No nesting under the primary config's directory
+      const nestedPath = join(
+        outDir, ".openclaw", "agents", ".openclaw", "permission-index-multi-config.json"
+      );
+      await expect(readFile(nestedPath, "utf-8")).rejects.toMatchObject({ code: "ENOENT" });
     });
   });
 });

--- a/packages/compatibility-layer/src/cli/__tests__/migrate.test.ts
+++ b/packages/compatibility-layer/src/cli/__tests__/migrate.test.ts
@@ -687,7 +687,7 @@ You are an agent that exercises the multi-config output path.
         outDir, "subagents", "code", ".openclaw", "agents", "multi-config.json"
       );
       const bootstrapPath = join(
-        outDir, "subagents", "code", ".openclaw", "bootstrap-manifest.json"
+        outDir, "subagents", "code", ".openclaw", "bootstrap-manifest-multi-config.json"
       );
       const skillsPath = join(
         outDir, "subagents", "code", ".openclaw", "skills-index.json"
@@ -745,6 +745,70 @@ You are an agent that exercises the multi-config output path.
         outDir, ".openclaw", "agents", ".openclaw", "permission-index-multi-config.json"
       );
       await expect(readFile(nestedPath, "utf-8")).rejects.toMatchObject({ code: "ENOENT" });
+    });
+
+    it("writes unique per-agent bootstrap manifests for same-directory primaries (no overwrite)", async () => {
+      // Arrange: two primary agents in the SAME source subdirectory.
+      // Regression for the converter overwrite bug: fixed-name
+      // .openclaw/bootstrap-manifest.json was clobbered by the last primary
+      // migrated; per-agent names must both survive.
+      const sourceDir = join(TEMP_DIR, "source-multi-same-dir");
+      const agentDir = join(sourceDir, "subagents", "code");
+      await mkdir(agentDir, { recursive: true });
+
+      const agentA = `---
+name: "Alpha Agent"
+description: "First same-dir primary"
+mode: primary
+---
+# Alpha Agent
+
+Alpha 六阶段工作流准则。
+`;
+      const agentB = `---
+name: "Beta Agent"
+description: "Second same-dir primary"
+mode: primary
+---
+# Beta Agent
+
+Beta 六阶段工作流准则。
+`;
+      await writeFile(join(agentDir, "alpha.md"), agentA);
+      await writeFile(join(agentDir, "beta.md"), agentB);
+
+      const outDir = join(TEMP_DIR, "output-multi-same-dir");
+
+      // Act
+      const result = await executeMigrate(
+        sourceDir,
+        { format: "openclaw", outDir },
+        defaultGlobalOptions
+      );
+
+      // Assert: both per-agent manifests exist with non-empty source guidance
+      expect(result.success).toBe(true);
+      expect(result.data?.successful).toBeGreaterThanOrEqual(2);
+
+      const alphaManifestPath = join(
+        outDir, "subagents", "code", ".openclaw", "bootstrap-manifest-alpha.json"
+      );
+      const betaManifestPath = join(
+        outDir, "subagents", "code", ".openclaw", "bootstrap-manifest-beta.json"
+      );
+
+      const alphaManifest = JSON.parse(await readFile(alphaManifestPath, "utf-8"));
+      const betaManifest = JSON.parse(await readFile(betaManifestPath, "utf-8"));
+      expect(alphaManifest.agentId).toBe("alpha");
+      expect(alphaManifest.guidance).toContain("Alpha 六阶段");
+      expect(betaManifest.agentId).toBe("beta");
+      expect(betaManifest.guidance).toContain("Beta 六阶段");
+
+      // No legacy single-file manifest is produced for multi-agent output
+      const legacyPath = join(
+        outDir, "subagents", "code", ".openclaw", "bootstrap-manifest.json"
+      );
+      await expect(readFile(legacyPath, "utf-8")).rejects.toMatchObject({ code: "ENOENT" });
     });
   });
 });

--- a/packages/compatibility-layer/src/cli/commands/info.ts
+++ b/packages/compatibility-layer/src/cli/commands/info.ts
@@ -108,6 +108,7 @@ const DOCUMENTATION_LINKS: Record<Platform, string> = {
   cursor: "https://docs.cursor.com/context/rules-for-ai",
   claude: "https://docs.anthropic.com/en/docs/build-with-claude/computer-use",
   windsurf: "https://docs.codeium.com/windsurf/overview",
+  openclaw: "https://docs.openclaw.ai/",
 };
 
 // ============================================================================

--- a/packages/compatibility-layer/src/cli/commands/migrate.ts
+++ b/packages/compatibility-layer/src/cli/commands/migrate.ts
@@ -199,12 +199,17 @@ const AGENT_FILE_EXTENSIONS = new Set([".md", ".json", ".txt", ""]);
 const isAgentFile = (fileName: string): boolean => {
   const ext = extname(fileName).toLowerCase();
   const baseName = basename(fileName).toLowerCase();
-  
+
   // Always include specific agent file names
   if (baseName === ".cursorrules" || baseName === "cursorrules") {
     return true;
   }
-  
+
+  // Skip OAC category index metadata (0-category.json — directory listing, not an agent)
+  if (baseName === "0-category.json") {
+    return false;
+  }
+
   return AGENT_FILE_EXTENSIONS.has(ext);
 };
 
@@ -459,11 +464,20 @@ const migrateFile = async (
         await writeFile(outputPath, primaryConfig.content, "utf-8");
       }
       
-      // Write additional files if present
+      // Write additional files if present.
+      // Additional config paths are relative to the source file's directory
+      // (targetDir), matching the primary config's output location. Joining
+      // them to dirname(outputPath) would nest them inside the primary
+      // config's own subdirectory (e.g. `.openclaw/agents/.openclaw/...`),
+      // producing wrong paths like `.openclaw/agents/.openclaw/permission-index.json`.
+      const relativeDir = dirname(relativePath);
+      const targetDir = relativeDir === "." ? outputDir : join(outputDir, relativeDir);
+
       for (let i = 1; i < result.configs.length; i++) {
         const additionalConfig = result.configs[i];
         if (additionalConfig) {
-          const additionalPath = join(dirname(outputPath), additionalConfig.fileName);
+          const additionalPath = join(targetDir, additionalConfig.fileName);
+          await mkdir(dirname(additionalPath), { recursive: true });
           await writeFile(additionalPath, additionalConfig.content, "utf-8");
         }
       }

--- a/packages/compatibility-layer/src/cli/types.ts
+++ b/packages/compatibility-layer/src/cli/types.ts
@@ -153,7 +153,7 @@ export const errorResult = (
 /**
  * Supported AI coding tool platforms
  */
-export type Platform = "oac" | "cursor" | "claude" | "windsurf";
+export type Platform = "oac" | "cursor" | "claude" | "windsurf" | "openclaw";
 
 /**
  * All supported platforms
@@ -163,6 +163,7 @@ export const PLATFORMS: readonly Platform[] = [
   "cursor",
   "claude",
   "windsurf",
+  "openclaw",
 ] as const;
 
 /**
@@ -173,6 +174,7 @@ export const PLATFORM_NAMES: Record<Platform, string> = {
   cursor: "Cursor IDE",
   claude: "Claude Code",
   windsurf: "Windsurf",
+  openclaw: "OpenClaw",
 } as const;
 
 /**

--- a/packages/compatibility-layer/src/core/AdapterRegistry.ts
+++ b/packages/compatibility-layer/src/core/AdapterRegistry.ts
@@ -336,6 +336,14 @@ export class AdapterRegistry {
     } catch (error) {
       // Adapter not yet implemented - skip silently
     }
+
+    try {
+      // OpenClaw
+      const { OpenClawAdapter } = await import("../adapters/OpenClawAdapter.js");
+      this.register(new OpenClawAdapter(), ["openclaw-gateway"]);
+    } catch (error) {
+      // Adapter not yet implemented - skip silently
+    }
   }
 }
 

--- a/packages/compatibility-layer/src/core/CapabilityMatrix.ts
+++ b/packages/compatibility-layer/src/core/CapabilityMatrix.ts
@@ -17,7 +17,7 @@ import type { OpenAgent, ToolCapabilities } from "../types.js";
 // Types
 // ============================================================================
 
-export type Platform = "oac" | "claude" | "cursor" | "windsurf";
+export type Platform = "oac" | "claude" | "cursor" | "windsurf" | "openclaw";
 
 /**
  * Feature categories for the capability matrix
@@ -79,21 +79,21 @@ const CAPABILITY_MATRIX: FeatureDefinition[] = [
     name: "multipleAgents",
     category: "agents",
     description: "Support for multiple agent definitions",
-    support: { oac: "full", claude: "full", cursor: "none", windsurf: "full" },
+    support: { oac: "full", claude: "full", cursor: "none", windsurf: "full", openclaw: "full" },
     notes: { cursor: "Single .cursorrules file only - agents will be merged" },
   },
   {
     name: "agentModes",
     category: "agents",
     description: "Primary/subagent mode distinction",
-    support: { oac: "full", claude: "full", cursor: "none", windsurf: "partial" },
+    support: { oac: "full", claude: "full", cursor: "none", windsurf: "partial", openclaw: "full" },
     notes: { windsurf: "Limited mode support" },
   },
   {
     name: "agentCategories",
     category: "agents",
     description: "Agent categorization (core, development, etc.)",
-    support: { oac: "full", claude: "partial", cursor: "none", windsurf: "partial" },
+    support: { oac: "full", claude: "partial", cursor: "none", windsurf: "partial", openclaw: "partial" },
   },
 
   // Permission Features
@@ -101,24 +101,25 @@ const CAPABILITY_MATRIX: FeatureDefinition[] = [
     name: "granularPermissions",
     category: "permissions",
     description: "Fine-grained allow/deny/ask patterns",
-    support: { oac: "full", claude: "none", cursor: "none", windsurf: "none" },
+    support: { oac: "full", claude: "none", cursor: "none", windsurf: "none", openclaw: "full" },
     notes: {
       claude: "Binary on/off only",
       cursor: "Binary on/off only",
       windsurf: "Binary on/off only",
+      openclaw: "Full granular via before_tool_call hook (no degradation)",
     },
   },
   {
     name: "askPermissions",
     category: "permissions",
     description: "Interactive permission requests",
-    support: { oac: "full", claude: "none", cursor: "none", windsurf: "none" },
+    support: { oac: "full", claude: "none", cursor: "none", windsurf: "none", openclaw: "full" },
   },
   {
     name: "pathPatterns",
     category: "permissions",
     description: "Glob patterns for file permissions",
-    support: { oac: "full", claude: "none", cursor: "none", windsurf: "partial" },
+    support: { oac: "full", claude: "none", cursor: "none", windsurf: "partial", openclaw: "full" },
   },
 
   // Tool Features
@@ -126,26 +127,26 @@ const CAPABILITY_MATRIX: FeatureDefinition[] = [
     name: "taskDelegation",
     category: "tools",
     description: "Agent-to-agent task delegation",
-    support: { oac: "full", claude: "full", cursor: "none", windsurf: "partial" },
+    support: { oac: "full", claude: "full", cursor: "none", windsurf: "partial", openclaw: "full" },
     notes: { cursor: "No delegation support" },
   },
   {
     name: "bashExecution",
     category: "tools",
     description: "Shell command execution",
-    support: { oac: "full", claude: "full", cursor: "full", windsurf: "full" },
+    support: { oac: "full", claude: "full", cursor: "full", windsurf: "full", openclaw: "full" },
   },
   {
     name: "fileOperations",
     category: "tools",
     description: "Read/write/edit file operations",
-    support: { oac: "full", claude: "full", cursor: "full", windsurf: "full" },
+    support: { oac: "full", claude: "full", cursor: "full", windsurf: "full", openclaw: "full" },
   },
   {
     name: "searchOperations",
     category: "tools",
     description: "Grep/glob search operations",
-    support: { oac: "full", claude: "full", cursor: "full", windsurf: "full" },
+    support: { oac: "full", claude: "full", cursor: "full", windsurf: "full", openclaw: "full" },
   },
 
   // Context Features
@@ -153,26 +154,26 @@ const CAPABILITY_MATRIX: FeatureDefinition[] = [
     name: "externalContext",
     category: "context",
     description: "External context file references",
-    support: { oac: "full", claude: "full", cursor: "none", windsurf: "full" },
+    support: { oac: "full", claude: "full", cursor: "none", windsurf: "full", openclaw: "full" },
     notes: { cursor: "Context must be inline in .cursorrules" },
   },
   {
     name: "contextPriority",
     category: "context",
     description: "Priority levels for context loading",
-    support: { oac: "full", claude: "none", cursor: "none", windsurf: "none" },
+    support: { oac: "full", claude: "none", cursor: "none", windsurf: "none", openclaw: "full" },
   },
   {
     name: "contextSubdirs",
     category: "context",
     description: "Nested context directory structure",
-    support: { oac: "full", claude: "full", cursor: "none", windsurf: "full" },
+    support: { oac: "full", claude: "full", cursor: "none", windsurf: "full", openclaw: "full" },
   },
   {
     name: "skillsSystem",
     category: "context",
     description: "Loadable skill modules",
-    support: { oac: "full", claude: "full", cursor: "none", windsurf: "partial" },
+    support: { oac: "full", claude: "full", cursor: "none", windsurf: "partial", openclaw: "full" },
   },
 
   // Model Features
@@ -180,24 +181,25 @@ const CAPABILITY_MATRIX: FeatureDefinition[] = [
     name: "modelSelection",
     category: "model",
     description: "Custom model selection",
-    support: { oac: "full", claude: "full", cursor: "full", windsurf: "full" },
+    support: { oac: "full", claude: "full", cursor: "full", windsurf: "full", openclaw: "full" },
   },
   {
     name: "temperatureControl",
     category: "model",
     description: "Temperature parameter control",
-    support: { oac: "full", claude: "none", cursor: "partial", windsurf: "partial" },
+    support: { oac: "full", claude: "none", cursor: "partial", windsurf: "partial", openclaw: "full" },
     notes: {
       claude: "Temperature not configurable",
       cursor: "Limited range",
       windsurf: "Maps to creativity setting",
+      openclaw: "Maps to params.temperature",
     },
   },
   {
     name: "maxSteps",
     category: "model",
     description: "Maximum execution steps limit",
-    support: { oac: "full", claude: "none", cursor: "none", windsurf: "none" },
+    support: { oac: "full", claude: "none", cursor: "none", windsurf: "none", openclaw: "none" },
   },
 
   // Advanced Features
@@ -205,20 +207,20 @@ const CAPABILITY_MATRIX: FeatureDefinition[] = [
     name: "hooks",
     category: "advanced",
     description: "Event hooks (PreToolUse, PostToolUse, etc.)",
-    support: { oac: "full", claude: "full", cursor: "none", windsurf: "none" },
+    support: { oac: "full", claude: "full", cursor: "none", windsurf: "none", openclaw: "full" },
     notes: { cursor: "No hook support", windsurf: "No hook support" },
   },
   {
     name: "dependencies",
     category: "advanced",
     description: "Agent dependency declarations",
-    support: { oac: "full", claude: "full", cursor: "none", windsurf: "partial" },
+    support: { oac: "full", claude: "full", cursor: "none", windsurf: "partial", openclaw: "partial" },
   },
   {
     name: "priorityLevels",
     category: "advanced",
     description: "Task priority levels",
-    support: { oac: "full", claude: "partial", cursor: "none", windsurf: "partial" },
+    support: { oac: "full", claude: "partial", cursor: "none", windsurf: "partial", openclaw: "partial" },
     notes: { oac: "4 levels", claude: "2 levels", windsurf: "2 levels" },
   },
 ];
@@ -442,12 +444,14 @@ export function getToolCapabilities(
     claude: "Claude Code",
     cursor: "Cursor IDE",
     windsurf: "Windsurf",
+    openclaw: "OpenClaw",
   };
 
   const configFormats: Record<Exclude<Platform, "oac">, ToolCapabilities["configFormat"]> = {
     claude: "json",
     cursor: "plain",
     windsurf: "json",
+    openclaw: "json",
   };
 
   const outputStructures: Record<
@@ -457,6 +461,7 @@ export function getToolCapabilities(
     claude: "directory",
     cursor: "single-file",
     windsurf: "directory",
+    openclaw: "directory",
   };
 
   return {

--- a/packages/compatibility-layer/src/core/TranslationEngine.ts
+++ b/packages/compatibility-layer/src/core/TranslationEngine.ts
@@ -211,9 +211,9 @@ export class TranslationEngine {
       warnings.push(...contextResult.warnings);
     }
 
-    // Translate skills (Claude-specific)
+    // Translate skills (Claude/OpenClaw-specific)
     let skills: string[] | undefined;
-    if (target === "claude" && agent.frontmatter.skills) {
+    if ((target === "claude" || target === "openclaw") && agent.frontmatter.skills) {
       const skillResult = mapSkillsToClaudeFormat(agent.frontmatter.skills);
       skills = skillResult.skills;
       warnings.push(...skillResult.warnings);

--- a/packages/compatibility-layer/src/index.ts
+++ b/packages/compatibility-layer/src/index.ts
@@ -157,6 +157,7 @@ export { BaseAdapter } from "./adapters/BaseAdapter.js";
 export { CursorAdapter } from "./adapters/CursorAdapter.js";
 export { ClaudeAdapter } from "./adapters/ClaudeAdapter.js";
 export { WindsurfAdapter } from "./adapters/WindsurfAdapter.js";
+export { OpenClawAdapter } from "./adapters/OpenClawAdapter.js";
 
 // ============================================================================
 // MAPPERS - Feature Translation (Phase 3)
@@ -207,10 +208,13 @@ export {
   hasGranularPermissions,
   hasAskPermissions,
   analyzePermissionDegradation,
+  createPermissionIndex,
   type PermissionPlatform,
   type BinaryPermissions,
   type PermissionMappingResult,
   type DegradationStrategy,
+  type PermissionIndex,
+  type PermissionIndexEntry,
 } from "./mappers/PermissionMapper.js";
 
 /**

--- a/packages/compatibility-layer/src/mappers/ContextMapper.ts
+++ b/packages/compatibility-layer/src/mappers/ContextMapper.ts
@@ -17,7 +17,7 @@ import type { ContextReference, SkillReference } from "../types.js";
 // Types
 // ============================================================================
 
-export type ContextPlatform = "oac" | "claude" | "cursor" | "windsurf";
+export type ContextPlatform = "oac" | "claude" | "cursor" | "windsurf" | "openclaw";
 
 /**
  * Result of a context path mapping operation
@@ -78,6 +78,14 @@ const CONTEXT_CONFIGS: Record<ContextPlatform, ContextConfig> = {
     extension: ".md",
     supportsSubdirs: true,
     supportsPriority: false,
+    inlineOnly: false,
+  },
+  openclaw: {
+    // OpenClaw references OAC context files in place (no copy) - same layout as oac
+    baseDir: ".opencode/context",
+    extension: ".md",
+    supportsSubdirs: true,
+    supportsPriority: true,
     inlineOnly: false,
   },
 };

--- a/packages/compatibility-layer/src/mappers/ModelMapper.ts
+++ b/packages/compatibility-layer/src/mappers/ModelMapper.ts
@@ -18,7 +18,7 @@
 // Types
 // ============================================================================
 
-export type ModelPlatform = "oac" | "claude" | "cursor" | "windsurf";
+export type ModelPlatform = "oac" | "claude" | "cursor" | "windsurf" | "openclaw";
 
 /**
  * Result of a model mapping operation

--- a/packages/compatibility-layer/src/mappers/PermissionMapper.ts
+++ b/packages/compatibility-layer/src/mappers/PermissionMapper.ts
@@ -19,7 +19,7 @@ import type { GranularPermission, PermissionRule } from "../types.js";
 // Types
 // ============================================================================
 
-export type PermissionPlatform = "oac" | "claude" | "cursor" | "windsurf";
+export type PermissionPlatform = "oac" | "claude" | "cursor" | "windsurf" | "openclaw";
 
 /**
  * Binary permission representation used by most tools
@@ -61,6 +61,8 @@ const PLATFORM_CAPABILITIES: Record<
   claude: { supportsGranular: false, supportsAsk: false },
   cursor: { supportsGranular: false, supportsAsk: false },
   windsurf: { supportsGranular: false, supportsAsk: false },
+  // OpenClaw supports full granular permissions + ask via before_tool_call hook (no degradation)
+  openclaw: { supportsGranular: true, supportsAsk: true },
 };
 
 // ============================================================================
@@ -351,4 +353,62 @@ export function analyzePermissionDegradation(
   }
 
   return warnings;
+}
+
+// ============================================================================
+// Permission Index Generation (OpenClaw — no degradation)
+// ============================================================================
+
+/**
+ * A single permission entry: an ordered pattern with its action.
+ * Order matters: consumers apply last-match-wins semantics.
+ */
+export interface PermissionIndexEntry {
+  pattern: string;
+  action: "allow" | "deny" | "ask";
+}
+
+/**
+ * Full permission index for one agent.
+ * tools: { toolName: ordered PermissionIndexEntry[] }
+ */
+export interface PermissionIndex {
+  agentId: string;
+  tools: Record<string, PermissionIndexEntry[]>;
+}
+
+/**
+ * Build a permission index from OAC granular permissions.
+ *
+ * Unlike binary degradation, this preserves the FULL permission table
+ * (pattern + action per tool) so a runtime hook (e.g. OpenClaw's
+ * before_tool_call) can enforce it with no fidelity loss.
+ *
+ * Entry order follows the original declaration order — consumers should
+ * apply LAST-MATCH-WINS (matching the OAC catch-all semantics).
+ *
+ * @param agentId - Agent identifier for the index
+ * @param permissions - OAC granular permission table
+ * @returns Structured permission index
+ */
+export function createPermissionIndex(
+  agentId: string,
+  permissions: GranularPermission
+): PermissionIndex {
+  const tools: Record<string, PermissionIndexEntry[]> = {};
+
+  for (const [tool, rule] of Object.entries(permissions)) {
+    if (rule === "allow" || rule === "deny" || rule === "ask") {
+      tools[tool] = [{ pattern: "*", action: rule }];
+    } else if (typeof rule === "boolean") {
+      tools[tool] = [{ pattern: "*", action: rule ? "allow" : "deny" }];
+    } else if (typeof rule === "object" && rule !== null) {
+      tools[tool] = Object.entries(rule).map(([pattern, action]) => ({
+        pattern,
+        action: action as "allow" | "deny" | "ask",
+      }));
+    }
+  }
+
+  return { agentId, tools };
 }

--- a/packages/compatibility-layer/src/mappers/ToolMapper.ts
+++ b/packages/compatibility-layer/src/mappers/ToolMapper.ts
@@ -20,7 +20,7 @@ import type { ToolAccess } from "../types.js";
 /**
  * Supported tool platforms for mapping
  */
-export type ToolPlatform = "oac" | "claude" | "cursor" | "windsurf";
+export type ToolPlatform = "oac" | "claude" | "cursor" | "windsurf" | "openclaw";
 
 /**
  * Tool mapping configuration for a specific platform
@@ -123,6 +123,29 @@ const TOOL_MAPPINGS: Record<Exclude<ToolPlatform, "oac">, ToolMappingConfig> = {
       delegate: "task",
     },
     unsupported: [], // Windsurf has equivalents for most
+  },
+
+  openclaw: {
+    fromOAC: {
+      bash: "exec",
+      read: "read",
+      write: "write",
+      edit: "edit",
+      glob: "glob",
+      grep: "grep",
+      task: "sessions_spawn", // Subagent delegation
+      patch: "edit",
+    },
+    toOAC: {
+      exec: "bash",
+      read: "read",
+      write: "write",
+      edit: "edit",
+      glob: "glob",
+      grep: "grep",
+      sessions_spawn: "task",
+    },
+    unsupported: [], // OpenClaw has equivalents for all OAC tools
   },
 };
 

--- a/packages/compatibility-layer/src/types.ts
+++ b/packages/compatibility-layer/src/types.ts
@@ -89,17 +89,13 @@ export const AgentModeSchema = z.enum(["primary", "subagent", "all"]);
 
 /**
  * Agent categories for organizational purposes.
+ *
+ * NOTE: Kept as a plain string instead of a strict enum. Real OAC metadata
+ * (agent-metadata.json) uses values like "core", "testing", "subagents/core",
+ * "subagents/system-builder" etc. — a strict enum rejected real assets and
+ * broke AgentLoader. Category is organizational metadata, not behavior.
  */
-export const AgentCategorySchema = z.enum([
-  "core",
-  "development",
-  "content",
-  "data",
-  "product",
-  "learning",
-  "meta",
-  "specialist",
-]);
+export const AgentCategorySchema = z.string();
 
 /**
  * Defines whether this is a primary agent or subagent.

--- a/packages/compatibility-layer/tests/unit/adapters/OpenClawAdapter.test.ts
+++ b/packages/compatibility-layer/tests/unit/adapters/OpenClawAdapter.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { OpenClawAdapter } from "../../../src/adapters/OpenClawAdapter";
+import type { OpenAgent } from "../../../src/types";
+
+/**
+ * Unit tests for OpenClawAdapter with 80%+ coverage
+ *
+ * Test strategy:
+ * 1. Adapter identity (name/displayName/configPath)
+ * 2. getCapabilities() — granular permissions is the key differentiator
+ * 3. validateConversion() — no granular degradation warnings
+ * 4. fromOAC() — three-channel output + permission index
+ * 5. toOAC() — phase 1 not implemented
+ * 6. Edge cases — missing fields, primary vs subagent, skill/skills variants
+ */
+
+function makeAgent(overrides: Partial<OpenAgent> = {}): OpenAgent {
+  return {
+    frontmatter: {
+      name: "TestAgent",
+      description: "Test agent for OpenClaw conversion",
+      mode: "primary",
+    },
+    metadata: {
+      id: "test-agent",
+      name: "TestAgent",
+      category: "core",
+      type: "agent",
+      version: "1.0.0",
+      author: "opencode",
+      tags: [],
+      dependencies: [],
+    },
+    systemPrompt: "## Workflow\nFollow the 6-stage process.",
+    contexts: [],
+    ...overrides,
+    frontmatter: {
+      name: "TestAgent",
+      description: "Test agent for OpenClaw conversion",
+      mode: "primary",
+      ...(overrides.frontmatter || {}),
+    },
+  } as OpenAgent;
+}
+
+describe("OpenClawAdapter", () => {
+  let adapter: OpenClawAdapter;
+
+  beforeEach(() => {
+    adapter = new OpenClawAdapter();
+  });
+
+  // ============================================================================
+  // ADAPTER IDENTITY
+  // ============================================================================
+
+  describe("adapter identity", () => {
+    it("has correct name", () => {
+      expect(adapter.name).toBe("openclaw");
+    });
+
+    it("has correct displayName", () => {
+      expect(adapter.displayName).toBe("OpenClaw");
+    });
+
+    it("returns correct config path", () => {
+      expect(adapter.getConfigPath()).toBe(".openclaw/");
+    });
+  });
+
+  // ============================================================================
+  // CAPABILITIES
+  // ============================================================================
+
+  describe("getCapabilities()", () => {
+    it("reports granular permission support (no degradation)", () => {
+      const capabilities = adapter.getCapabilities();
+
+      expect(capabilities.name).toBe("openclaw");
+      expect(capabilities.supportsGranularPermissions).toBe(true);
+      expect(capabilities.supportsAsk).toBeUndefined(); // not a ToolCapabilities field
+      expect(capabilities.supportsMultipleAgents).toBe(true);
+      expect(capabilities.supportsSkills).toBe(true);
+      expect(capabilities.supportsHooks).toBe(true);
+      expect(capabilities.supportsTemperature).toBe(true);
+      expect(capabilities.configFormat).toBe("json");
+      expect(capabilities.outputStructure).toBe("directory");
+    });
+  });
+
+  // ============================================================================
+  // VALIDATION
+  // ============================================================================
+
+  describe("validateConversion()", () => {
+    it("warns when name is missing", () => {
+      const agent = makeAgent({ frontmatter: { name: "" } });
+      const warnings = adapter.validateConversion(agent);
+      expect(warnings.some((w) => w.includes("name is required"))).toBe(true);
+    });
+
+    it("warns when description is missing", () => {
+      const agent = makeAgent({ frontmatter: { description: "" } });
+      const warnings = adapter.validateConversion(agent);
+      expect(warnings.some((w) => w.includes("description is required"))).toBe(true);
+    });
+
+    it("does NOT warn about granular permissions (OpenClaw supports them)", () => {
+      const agent = makeAgent({
+        frontmatter: {
+          permission: {
+            bash: { "*": "deny", "git status*": "allow" },
+            edit: { "**/*.env*": "deny" },
+          },
+        },
+      });
+      const warnings = adapter.validateConversion(agent);
+      expect(warnings.some((w) => w.includes("degrad"))).toBe(false);
+    });
+
+    it("warns about maxSteps (not supported in phase 1)", () => {
+      const agent = makeAgent({ frontmatter: { maxSteps: 50 } });
+      const warnings = adapter.validateConversion(agent);
+      expect(warnings.some((w) => w.includes("maxSteps"))).toBe(true);
+    });
+  });
+
+  // ============================================================================
+  // fromOAC()
+  // ============================================================================
+
+  describe("fromOAC()", () => {
+    it("generates per-agent config fragment", async () => {
+      const result = await adapter.fromOAC(makeAgent());
+
+      expect(result.success).toBe(true);
+      expect(result.configs.some((c) => c.fileName.includes("agents/"))).toBe(true);
+
+      const agentConfig = result.configs.find((c) =>
+        c.fileName.includes("agents/")
+      );
+      expect(agentConfig).toBeDefined();
+      const parsed = JSON.parse(agentConfig!.content) as Record<string, unknown>;
+      expect(parsed.id).toBe("test-agent");
+      expect(parsed.name).toBe("TestAgent");
+      // entryType removed — OpenClaw schema rejects unknown fields
+      expect(parsed.entryType).toBeUndefined();
+    });
+
+    it("generates bootstrap manifest for primary agents", async () => {
+      const result = await adapter.fromOAC(makeAgent());
+
+      const manifest = result.configs.find((c) =>
+        c.fileName.includes("bootstrap-manifest")
+      );
+      expect(manifest).toBeDefined();
+      const parsed = JSON.parse(manifest!.content) as {
+        agentId: string;
+        guidance: string;
+      };
+      expect(parsed.agentId).toBe("test-agent");
+      expect(parsed.guidance).toContain("6-stage");
+    });
+
+    it("does NOT generate bootstrap manifest for subagents", async () => {
+      const agent = makeAgent({
+        frontmatter: { mode: "subagent" },
+        metadata: { id: "test-subagent", type: "subagent" },
+      });
+      const result = await adapter.fromOAC(agent);
+
+      expect(result.configs.some((c) => c.fileName.includes("bootstrap"))).toBe(
+        false
+      );
+      const subagentConfig = result.configs.find((c) =>
+        c.fileName.includes("agents/")
+      );
+      expect(subagentConfig).toBeDefined();
+      const parsed = JSON.parse(subagentConfig!.content) as Record<string, unknown>;
+      // No entryType field — mode routing is expressed by fileName/OpenClaw
+      // structure, and OpenClaw schema rejects unknown fields.
+      expect(parsed.entryType).toBeUndefined();
+    });
+
+    it("generates skills index when skills present (array form)", async () => {
+      const agent = makeAgent({ frontmatter: { skills: ["task-management"] } });
+      const result = await adapter.fromOAC(agent);
+
+      const index = result.configs.find((c) =>
+        c.fileName.includes("skills-index")
+      );
+      expect(index).toBeDefined();
+      const parsed = JSON.parse(index!.content) as { skills: string[] };
+      expect(parsed.skills).toContain("task-management");
+    });
+
+    it("generates skills index when skills present (object form)", async () => {
+      const agent = makeAgent({
+        frontmatter: { skills: [{ name: "context-manager" }] },
+      });
+      const result = await adapter.fromOAC(agent);
+
+      const index = result.configs.find((c) =>
+        c.fileName.includes("skills-index")
+      );
+      expect(index).toBeDefined();
+      const parsed = JSON.parse(index!.content) as { skills: string[] };
+      expect(parsed.skills).toContain("context-manager");
+    });
+
+    it("preserves full permission table in per-agent permission fragment (no degradation)", async () => {
+      const agent = makeAgent({
+        frontmatter: {
+          permission: {
+            bash: { "*": "deny", "git status*": "allow" },
+            edit: { "**/*.env*": "deny" },
+            question: "allow",
+          },
+        },
+      });
+      const result = await adapter.fromOAC(agent);
+
+      // Per-agent fragment: fileName carries the agentId so multiple agents
+      // with permission tables never overwrite each other.
+      const index = result.configs.find((c) =>
+        c.fileName.includes("permission-index")
+      );
+      expect(index).toBeDefined();
+      expect(index!.fileName).toBe(".openclaw/permission-index-test-agent.json");
+      const parsed = JSON.parse(index!.content) as {
+        agentId: string;
+        tools: Record<string, Array<{ pattern: string; action: string }>>;
+      };
+      expect(parsed.agentId).toBe("test-agent");
+      expect(parsed.tools.bash).toHaveLength(2); // patterns preserved
+      expect(parsed.tools.bash).toEqual([
+        { pattern: "*", action: "deny" },
+        { pattern: "git status*", action: "allow" },
+      ]);
+      expect(parsed.tools.question).toEqual([
+        { pattern: "*", action: "allow" },
+      ]);
+    });
+
+    it("emits a unique permission fragment per agent (no cross-agent overwrite)", async () => {
+      const agentA = makeAgent({
+        frontmatter: { permission: { bash: { "*": "allow" } } },
+      });
+      const agentB = makeAgent({
+        metadata: { ...agentA.metadata, id: "agent-b" },
+        frontmatter: { permission: { read: { "*": "deny" } } },
+      });
+
+      const [resultA, resultB] = await Promise.all([
+        adapter.fromOAC(agentA),
+        adapter.fromOAC(agentB),
+      ]);
+
+      const fileNameA = resultA.configs.find((c) =>
+        c.fileName.includes("permission-index")
+      )!.fileName;
+      const fileNameB = resultB.configs.find((c) =>
+        c.fileName.includes("permission-index")
+      )!.fileName;
+      expect(fileNameA).toBe(".openclaw/permission-index-test-agent.json");
+      expect(fileNameB).toBe(".openclaw/permission-index-agent-b.json");
+      expect(fileNameA).not.toBe(fileNameB);
+    });
+
+    it("maps temperature to params", async () => {
+      const agent = makeAgent({ frontmatter: { temperature: 0.1 } });
+      const result = await adapter.fromOAC(agent);
+
+      const agentConfig = result.configs.find((c) =>
+        c.fileName.includes("agents/")
+      );
+      const parsed = JSON.parse(agentConfig!.content) as {
+        params?: { temperature: number };
+      };
+      expect(parsed.params?.temperature).toBe(0.1);
+    });
+
+    it("maps model reference", async () => {
+      const agent = makeAgent({ frontmatter: { model: "opencode-go/deepseek-v4-flash" } });
+      const result = await adapter.fromOAC(agent);
+
+      const agentConfig = result.configs.find((c) =>
+        c.fileName.includes("agents/")
+      );
+      const parsed = JSON.parse(agentConfig!.content) as { model?: string };
+      expect(parsed.model).toBe("opencode-go/deepseek-v4-flash");
+    });
+  });
+
+  // ============================================================================
+  // toOAC()
+  // ============================================================================
+
+  describe("toOAC()", () => {
+    it("rejects with phase-1 not-implemented error", async () => {
+      await expect(adapter.toOAC("{}")).rejects.toThrow(
+        "not implemented in phase 1"
+      );
+    });
+  });
+});

--- a/packages/compatibility-layer/tests/unit/adapters/OpenClawAdapter.test.ts
+++ b/packages/compatibility-layer/tests/unit/adapters/OpenClawAdapter.test.ts
@@ -154,12 +154,37 @@ describe("OpenClawAdapter", () => {
         c.fileName.includes("bootstrap-manifest")
       );
       expect(manifest).toBeDefined();
+      // Per-agent file name (same pattern as permission-index-{agentId}.json)
+      // so same-directory primaries never overwrite each other.
+      expect(manifest!.fileName).toBe(".openclaw/bootstrap-manifest-test-agent.json");
       const parsed = JSON.parse(manifest!.content) as {
         agentId: string;
         guidance: string;
       };
       expect(parsed.agentId).toBe("test-agent");
       expect(parsed.guidance).toContain("6-stage");
+    });
+
+    it("emits a unique bootstrap manifest per primary agent (no cross-agent overwrite)", async () => {
+      const agentA = makeAgent();
+      const agentB = makeAgent({
+        metadata: { ...agentA.metadata, id: "agent-b" },
+      });
+
+      const [resultA, resultB] = await Promise.all([
+        adapter.fromOAC(agentA),
+        adapter.fromOAC(agentB),
+      ]);
+
+      const fileNameA = resultA.configs.find((c) =>
+        c.fileName.includes("bootstrap-manifest")
+      )!.fileName;
+      const fileNameB = resultB.configs.find((c) =>
+        c.fileName.includes("bootstrap-manifest")
+      )!.fileName;
+      expect(fileNameA).toBe(".openclaw/bootstrap-manifest-test-agent.json");
+      expect(fileNameB).toBe(".openclaw/bootstrap-manifest-agent-b.json");
+      expect(fileNameA).not.toBe(fileNameB);
     });
 
     it("does NOT generate bootstrap manifest for subagents", async () => {

--- a/packages/compatibility-layer/tests/unit/mappers/PermissionIndex.test.ts
+++ b/packages/compatibility-layer/tests/unit/mappers/PermissionIndex.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { createPermissionIndex } from "../../../src/mappers/PermissionMapper";
+
+/**
+ * Unit tests for createPermissionIndex (OpenClaw no-degradation index).
+ *
+ * The index must preserve:
+ * 1. Full granular rules (no binary simplification)
+ * 2. Declaration order (last-match-wins semantics for the hook consumer)
+ * 3. Literal / boolean / record rule forms
+ */
+
+describe("createPermissionIndex", () => {
+  it("handles literal rules", () => {
+    const index = createPermissionIndex("test-agent", {
+      question: "allow",
+    });
+
+    expect(index.agentId).toBe("test-agent");
+    expect(index.tools.question).toEqual([{ pattern: "*", action: "allow" }]);
+  });
+
+  it("handles boolean rules", () => {
+    const index = createPermissionIndex("test-agent", {
+      read: true,
+      write: false,
+    });
+
+    expect(index.tools.read).toEqual([{ pattern: "*", action: "allow" }]);
+    expect(index.tools.write).toEqual([{ pattern: "*", action: "deny" }]);
+  });
+
+  it("preserves full granular records with order (last-match-wins)", () => {
+    const index = createPermissionIndex("test-agent", {
+      bash: {
+        "*": "deny",
+        "git status*": "allow",
+        "sudo *": "ask",
+      },
+    });
+
+    expect(index.tools.bash).toEqual([
+      { pattern: "*", action: "deny" },
+      { pattern: "git status*", action: "allow" },
+      { pattern: "sudo *", action: "ask" },
+    ]);
+  });
+
+  it("handles mixed rule forms across tools", () => {
+    const index = createPermissionIndex("test-agent", {
+      bash: { "*": "deny" },
+      edit: { "**/*.env*": "deny", "node_modules/**": "deny" },
+      task: { contextscout: "allow", "*": "deny" },
+      question: "ask",
+    });
+
+    expect(index.tools.bash).toEqual([{ pattern: "*", action: "deny" }]);
+    expect(index.tools.edit).toHaveLength(2);
+    expect(index.tools.task).toEqual([
+      { pattern: "contextscout", action: "allow" },
+      { pattern: "*", action: "deny" },
+    ]);
+    expect(index.tools.question).toEqual([{ pattern: "*", action: "ask" }]);
+  });
+
+  it("returns empty tools for empty permissions", () => {
+    const index = createPermissionIndex("test-agent", {});
+    expect(index.tools).toEqual({});
+  });
+
+  it("does NOT degrade granular rules to binary (no simplification)", () => {
+    const index = createPermissionIndex("test-agent", {
+      bash: { "*": "deny", "ls *": "allow" },
+    });
+
+    // If degraded to binary this would be { bash: false } — instead full patterns survive
+    expect(index.tools.bash).toHaveLength(2);
+    expect(index.tools.bash?.[0]?.pattern).toBe("*");
+    expect(index.tools.bash?.[0]?.action).toBe("deny");
+    expect(index.tools.bash?.[1]?.action).toBe("allow");
+  });
+});


### PR DESCRIPTION
## Description

Adds an `OpenClawAdapter` to the compatibility layer, letting OAC agents/skills
assets convert to the OpenClaw gateway platform — with **no permission degradation**.

Follows the existing `BaseAdapter` pattern (alongside Claude / Cursor / Windsurf
adapters). Phase 1 is fromOAC one-way; toOAC is planned for phase 2.

## Type of Change
- [x] New feature (agent, command, tool)

## Checklist
- [x] Tests pass locally (compatibility-layer suite: 613 passed)
- [x] Documentation updated
- [x] Follows CONTRIBUTING.md

## What
- `packages/compatibility-layer/src/adapters/OpenClawAdapter.ts` — fromOAC
  conversion producing per-agent config fragments:
  - agents.list entry / subagent config (`.openclaw/agents/{id}.json`)
  - bootstrap manifest for primary agents (`.openclaw/bootstrap-manifest.json`)
  - skills index (`.openclaw/skills-index.json`)
  - **per-agent permission fragment** (`.openclaw/permission-index-{id}.json`)
- `PermissionMapper` extension: `createPermissionIndex()` preserves the FULL
  granular table (pattern + action per tool) in declaration order, instead of
  degrading to binary allow/deny. Consumers apply last-match-wins (matching
  OpenCode's permission semantics).

## Why
- Claude/Cursor/Windsurf adapters degrade granular permissions to binary
  on/off (warnings emitted). OpenClaw supports full granular enforcement via a
  `before_tool_call` hook, so the adapter can keep every allow/deny/ask rule —
  no fidelity loss, no hidden permission widening.

## How
- Conversion is additive: no upstream files modified, no existing behavior changed.
- `createPermissionIndex` iterates the OAC permission table per tool and emits
  ordered `{pattern, action}` entries; runtime hook (downstream, in the fork)
  evaluates them with last-match-wins + fail-closed default.
- Note (deliberate, documented): tool groups without a `*` catch-all (e.g. an
  edit blacklist) are enforced fail-closed on OpenClaw (stricter than OpenCode's
  default-allow); this is a safety hardening, not a permission widening. An
  optional `*: allow` injection can restore exact blacklist semantics.

## Testing
- [x] 34/34 real OAC agents converted; `config validate` passes for all 8 primary agents
- [x] Permission coverage: 24 agents with permission tables fully preserved
- [x] compatibility-layer suite: 613 passed (incl. new adapter + mapper tests)
- [x] End-to-end: install flow verified in isolated env (PLUGIN_DEST), ACP
  golden-standard comparison (acpx opencode vs openclaw exec) on the same task
- [x] Full plugin suite (107 tests) + integration docs in the fork repo (oac-openclaw)
