### PR TITLE
feat(tools): add MiniMax image generation

### DIFF
--- a/.opencode/tool/index.ts
+++ b/.opencode/tool/index.ts
@@ -16,6 +16,17 @@ export {
   default as gemini  // Default export (edit tool)
 } from "./gemini"
 
+// MiniMax image generation tool
+export {
+  generate as minimaxGenerate,
+  generateImage as generateMiniMaxImage,
+  type MiniMaxImageModel,
+  type MiniMaxImageOptions,
+  type MiniMaxImageRegion,
+  type MiniMaxImageResponseFormat,
+  type MiniMaxImageResult,
+} from "./minimax"
+
 // Environment variable utilities
 export {
   loadEnvVariables,

--- a/.opencode/tool/minimax/index.test.ts
+++ b/.opencode/tool/minimax/index.test.ts
@@ -1,0 +1,92 @@
+/** Tests for MiniMax image request construction and response parsing. */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { generateImage } from "./index"
+
+const originalFetch = globalThis.fetch
+
+beforeEach(() => {
+  process.env.MINIMAX_API_KEY = "test-api-key"
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  delete process.env.MINIMAX_API_KEY
+})
+
+describe("generateImage", () => {
+  test("uses the global endpoint and parses URL images", async () => {
+    let requestUrl = ""
+    let requestInit: RequestInit | undefined
+    globalThis.fetch = (async (input, init) => {
+      requestUrl = String(input)
+      requestInit = init
+      return Response.json({
+        data: { image_urls: ["https://images.example.test/generated.png"] },
+        metadata: { success_count: 1, failed_count: 0 },
+        base_resp: { status_code: 0 },
+      })
+    }) as typeof fetch
+
+    const result = await generateImage("A paper-cut city skyline", {
+      aspectRatio: "16:9",
+      responseFormat: "url",
+      seed: 42,
+      n: 1,
+      promptOptimizer: true,
+    })
+
+    expect(requestUrl).toBe("https://api.minimax.io/v1/image_generation")
+    expect(requestInit?.headers).toEqual({
+      Authorization: "Bearer test-api-key",
+      "Content-Type": "application/json",
+    })
+    expect(JSON.parse(String(requestInit?.body))).toEqual({
+      model: "image-01",
+      prompt: "A paper-cut city skyline",
+      aspect_ratio: "16:9",
+      response_format: "url",
+      seed: 42,
+      n: 1,
+      prompt_optimizer: true,
+    })
+    expect(result).toEqual({
+      images: ["https://images.example.test/generated.png"],
+      responseFormat: "url",
+      successCount: 1,
+      failedCount: 0,
+    })
+  })
+
+  test("uses the China endpoint and parses base64 images", async () => {
+    let requestUrl = ""
+    globalThis.fetch = (async (input) => {
+      requestUrl = String(input)
+      return Response.json({
+        data: { image_base64: ["aW1hZ2U="] },
+        metadata: { success_count: 1, failed_count: 0 },
+        base_resp: { status_code: 0 },
+      })
+    }) as typeof fetch
+
+    const result = await generateImage("A geometric fox", {
+      region: "china",
+      responseFormat: "base64",
+      width: 1024,
+      height: 1024,
+    })
+
+    expect(requestUrl).toBe("https://api.minimaxi.com/v1/image_generation")
+    expect(result.images).toEqual(["aW1hZ2U="])
+    expect(result.responseFormat).toBe("base64")
+  })
+
+  test("reports API response failures", async () => {
+    globalThis.fetch = (async () =>
+      Response.json({
+        base_resp: { status_code: 2013, status_msg: "Invalid input parameters" },
+      })) as typeof fetch
+
+    await expect(generateImage("A geometric fox")).rejects.toThrow("Invalid input parameters")
+  })
+})

--- a/.opencode/tool/minimax/index.ts
+++ b/.opencode/tool/minimax/index.ts
@@ -1,0 +1,149 @@
+/**
+ * MiniMax Image Tool
+ *
+ * Generates images from text with the regional MiniMax image API.
+ */
+
+import { tool } from "@opencode-ai/plugin/tool"
+import { getApiKey } from "../env"
+
+export type MiniMaxImageRegion = "global" | "china"
+export type MiniMaxImageModel = "image-01"
+export type MiniMaxImageResponseFormat = "url" | "base64"
+
+export interface MiniMaxImageOptions {
+  region?: MiniMaxImageRegion
+  model?: MiniMaxImageModel
+  aspectRatio?: "1:1" | "16:9" | "4:3" | "3:2" | "2:3" | "3:4" | "9:16" | "21:9"
+  width?: number
+  height?: number
+  responseFormat?: MiniMaxImageResponseFormat
+  seed?: number
+  n?: number
+  promptOptimizer?: boolean
+}
+
+export interface MiniMaxImageResult {
+  images: string[]
+  responseFormat: MiniMaxImageResponseFormat
+  successCount: number
+  failedCount: number
+}
+
+interface MiniMaxImageResponse {
+  data?: {
+    image_urls?: string[]
+    image_base64?: string[]
+  }
+  metadata?: {
+    success_count?: number
+    failed_count?: number
+  }
+  base_resp?: {
+    status_code?: number
+    status_msg?: string
+  }
+}
+
+const ENDPOINTS: Record<MiniMaxImageRegion, string> = {
+  global: "https://api.minimax.io/v1/image_generation",
+  china: "https://api.minimaxi.com/v1/image_generation",
+}
+
+function compactRequest(values: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(values).filter(([, value]) => value !== undefined))
+}
+
+export async function generateImage(
+  prompt: string,
+  options: MiniMaxImageOptions = {},
+): Promise<MiniMaxImageResult> {
+  if ((options.width === undefined) !== (options.height === undefined)) {
+    throw new Error("MiniMax image width and height must be provided together")
+  }
+
+  const apiKey = await getApiKey("MINIMAX_API_KEY")
+  const region = options.region ?? "global"
+  const responseFormat = options.responseFormat ?? "url"
+  const request = compactRequest({
+    model: options.model ?? "image-01",
+    prompt,
+    aspect_ratio: options.aspectRatio,
+    width: options.width,
+    height: options.height,
+    response_format: responseFormat,
+    seed: options.seed,
+    n: options.n,
+    prompt_optimizer: options.promptOptimizer,
+  })
+
+  const response = await fetch(ENDPOINTS[region], {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(request),
+  })
+
+  if (!response.ok) {
+    throw new Error(`MiniMax image API request failed with HTTP ${response.status}`)
+  }
+
+  const body = (await response.json()) as MiniMaxImageResponse
+  if (body.base_resp?.status_code !== 0) {
+    throw new Error(body.base_resp?.status_msg || "MiniMax image generation failed")
+  }
+
+  const images = responseFormat === "base64" ? body.data?.image_base64 : body.data?.image_urls
+  if (!images?.length) {
+    throw new Error("MiniMax image generation returned no images")
+  }
+
+  return {
+    images,
+    responseFormat,
+    successCount: body.metadata?.success_count ?? images.length,
+    failedCount: body.metadata?.failed_count ?? 0,
+  }
+}
+
+export const generate = tool({
+  description: "Generate images from a text prompt with MiniMax",
+  args: {
+    prompt: tool.schema.string().describe("Text description of the image to generate"),
+    region: tool.schema.enum(["global", "china"]).optional().describe("API region (default: global)"),
+    model: tool.schema.enum(["image-01"]).optional().describe("Image model (default: image-01)"),
+    aspect_ratio: tool.schema
+      .enum(["1:1", "16:9", "4:3", "3:2", "2:3", "3:4", "9:16", "21:9"])
+      .optional()
+      .describe("Generated image aspect ratio"),
+    width: tool.schema.number().int().optional().describe("Image width in pixels; provide with height"),
+    height: tool.schema.number().int().optional().describe("Image height in pixels; provide with width"),
+    response_format: tool.schema.enum(["url", "base64"]).optional().describe("Image response format"),
+    seed: tool.schema.number().int().optional().describe("Seed for reproducible generation"),
+    n: tool.schema.number().int().min(1).max(9).optional().describe("Number of images to generate"),
+    prompt_optimizer: tool.schema.boolean().optional().describe("Enable prompt optimization"),
+  },
+  async execute(args) {
+    try {
+      const result = await generateImage(args.prompt, {
+        region: args.region,
+        model: args.model,
+        aspectRatio: args.aspect_ratio,
+        width: args.width,
+        height: args.height,
+        responseFormat: args.response_format,
+        seed: args.seed,
+        n: args.n,
+        promptOptimizer: args.prompt_optimizer,
+      })
+      return JSON.stringify(result)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      return `Error: ${message}`
+    }
+  },
+})
+
+export default generate

--- a/registry.json
+++ b/registry.json
@@ -671,6 +671,22 @@
         "category": "specialized"
       },
       {
+        "id": "minimax",
+        "name": "MiniMax Image Tool",
+        "type": "tool",
+        "path": ".opencode/tool/minimax/index.ts",
+        "description": "Text-to-image generation using the MiniMax image API",
+        "tags": [
+          "ai",
+          "images",
+          "minimax"
+        ],
+        "dependencies": [
+          "tool:env"
+        ],
+        "category": "specialized"
+      },
+      {
         "id": "env",
         "name": "Environment Manager",
         "type": "tool",


### PR DESCRIPTION
Reason: OpenAgents Control has no MiniMax text-to-image tool for its global and China image API regions.

This change:
- adds a registered MiniMax image-generation tool with bearer authentication
- supports the documented text-to-image request controls and regional endpoints
- parses URL and base64 images together with generation metadata
- tests request construction, regional routing, response parsing, and API failures

Checks:
- `cd .opencode/tool && bun test minimax/index.test.ts`
- `cd .opencode/tool && bun run type-check`
- `bun run scripts/registry/validate-registry.ts`
