### PR TITLE
fix: keep wildcard permission denies as fallbacks

### DIFF
--- a/.opencode/agent/subagents/code/build-agent.md
+++ b/.opencode/agent/subagents/code/build-agent.md
@@ -5,6 +5,7 @@ mode: subagent
 temperature: 0.1
 permission:
   bash:
+    "*": "deny"
     "tsc": "allow"
     "mypy": "allow"
     "go build": "allow"
@@ -14,14 +15,13 @@ permission:
     "yarn build": "allow"
     "pnpm build": "allow"
     "python -m build": "allow"
-    "*": "deny"
   edit:
     "**/*": "deny"
   write:
     "**/*": "deny"
   task:
-    contextscout: "allow"
     "*": "deny"
+    contextscout: "allow"
 ---
 
 # BuildAgent

--- a/.opencode/agent/subagents/code/test-engineer.md
+++ b/.opencode/agent/subagents/code/test-engineer.md
@@ -5,6 +5,7 @@ mode: subagent
 temperature: 0.1
 permission:
   bash:
+    "*": "deny"
     "npx vitest *": "allow"
     "npx jest *": "allow"
     "pytest *": "allow"
@@ -17,7 +18,6 @@ permission:
     "cargo test *": "allow"
     "rm -rf *": "ask"
     "sudo *": "deny"
-    "*": "deny"
   edit:
     "**/*.env*": "deny"
     "**/*.key": "deny"

--- a/.opencode/agent/subagents/core/context-manager.md
+++ b/.opencode/agent/subagents/core/context-manager.md
@@ -11,11 +11,11 @@ permission:
   glob:
     "*": "allow"
   bash:
+    "*": "deny"
     "find .opencode/context*": "allow"
     "ls -la .opencode/context*": "allow"
     "mkdir -p .opencode/context*": "allow"
     "mv .opencode/context*": "allow"
-    "*": "deny"
   edit:
     ".opencode/context/**/*.md": "allow"
     ".opencode/context/**/*.json": "allow"

--- a/.opencode/agent/subagents/core/documentation.md
+++ b/.opencode/agent/subagents/core/documentation.md
@@ -13,8 +13,8 @@ permission:
     "**/*.key": "deny"
     "**/*.secret": "deny"
   task:
-    contextscout: "allow"
     "*": "deny"
+    contextscout: "allow"
 ---
 
 # DocWriter

--- a/.opencode/agent/subagents/core/task-manager.md
+++ b/.opencode/agent/subagents/core/task-manager.md
@@ -16,9 +16,9 @@ permission:
     "node_modules/**": "deny"
     ".git/**": "deny"
   task:
+    "*": "deny"
     contextscout: "allow"
     externalscout: "allow"
-    "*": "deny"
   skill:
     "*": "deny"
     "task-management": "allow"

--- a/.opencode/agent/subagents/system-builder/context-organizer.md
+++ b/.opencode/agent/subagents/system-builder/context-organizer.md
@@ -5,8 +5,8 @@ mode: subagent
 temperature: 0.1
 permission:
   task:
-    contextscout: "allow"
     "*": "deny"
+    contextscout: "allow"
   edit:
     "**/*.env*": "deny"
     "**/*.key": "deny"

--- a/.opencode/agent/subagents/system-builder/workflow-designer.md
+++ b/.opencode/agent/subagents/system-builder/workflow-designer.md
@@ -5,8 +5,8 @@ mode: subagent
 temperature: 0.1
 permission:
   task:
-    contextscout: "allow"
     "*": "deny"
+    contextscout: "allow"
   edit:
     "**/*.env*": "deny"
     "**/*.key": "deny"


### PR DESCRIPTION
## Summary

Fixes #349 by moving each permission map's catch-all "*" = "deny" rule before its specific allow rules in the affected agent definitions.

Changed maps:
- .opencode/agent/subagents/code/build-agent.md — bash, task
- .opencode/agent/subagents/code/test-engineer.md — bash
- .opencode/agent/subagents/core/context-manager.md — bash
- .opencode/agent/subagents/core/task-manager.md — task
- .opencode/agent/subagents/core/documentation.md — task
- .opencode/agent/subagents/system-builder/context-organizer.md — task
- .opencode/agent/subagents/system-builder/workflow-designer.md — task

This is an ordering-only change: no permission patterns, actions, agent behavior, or non-permission content were changed. The bug-fixer file mentioned in the issue is not present on the current main branch, so it is intentionally not included.

## Verification

- 7 files changed.
- 8 wildcard-deny lines relocated (two in BuildAgent, one in each other affected file).
- GitHub commit diff reports exactly 8 additions and 8 deletions.
- No full test suite run; this PR only changes YAML frontmatter ordering.