### PR TITLE
docs: point plugin setup links at the sections that replaced the removed guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ Add a login endpoint
 
 **Documentation:**
 - [Plugin README](./plugins/claude-code/README.md) - Complete plugin documentation
-- [First-Time Setup](./plugins/claude-code/FIRST-TIME-SETUP.md) - Step-by-step guide
-- [Quick Start](./plugins/claude-code/QUICK-START.md) - Quick reference
+- [Installation](./plugins/claude-code/README.md#-installation) - Step-by-step setup guide
+- [Quick Start](./plugins/claude-code/README.md#-quick-start) - Quick reference
 
 **Status:** BETA - Actively tested and ready for early adopters
 


### PR DESCRIPTION
hi, i am an AI agent (Claude) opening this on behalf of Anton Dzyatkovsky, who reviews what i open.

## Description
The "Documentation" list under the Claude Code plugin section of the root README links to `plugins/claude-code/FIRST-TIME-SETUP.md` and `plugins/claude-code/QUICK-START.md`. Both files were removed in #225 (2026-02-19, "overhaul Claude Code plugin for correctness and spec compliance"), so both links have been 404 on github.com since then. The root README is the first thing a new plugin user opens, and these are the two links that promise to get them started.

The plugin README absorbed that content: it has an `Installation` section (marketplace and local options) and a `Quick Start` section. This PR repoints the two links at those sections and keeps the list otherwise as it was.

## Type of Change
- [ ] New feature (agent, command, tool)
- [ ] Bug fix
- [x] Documentation
- [ ] Refactoring
- [ ] CI/CD

## Checklist
- [x] Tests pass locally (markdown only, no code touched)
- [x] Documentation updated (if needed)
- [x] Follows [CONTRIBUTING.md](docs/contributing/CONTRIBUTING.md)

## Testing
- `curl` on the blob URLs from `main`: `plugins/claude-code/FIRST-TIME-SETUP.md` 404, `plugins/claude-code/QUICK-START.md` 404, `plugins/claude-code/README.md` 200.
- Rendered anchor ids on the plugin README: `user-content--installation` and `user-content--quick-start`, which is what `#-installation` and `#-quick-start` resolve to (GitHub drops the emoji from the heading slug).
- `git log` on the two removed paths: last touch is #225, status `removed`. No other file in the tree references either name.
